### PR TITLE
Reference bottles for older macOS versions

### DIFF
--- a/automoc4.rb
+++ b/automoc4.rb
@@ -4,6 +4,13 @@ class Automoc4 < Formula
   url "http://download.kde.org/stable/automoc4/0.9.88/automoc4-0.9.88.tar.bz2"
   sha256 "234116f4c05ae21d828594d652b4c4a052ef75727e2d8a4f3a4fb605de9e4c49"
 
+  bottle do
+    root_url "https://homebrew.bintray.com/bottles"
+    sha256 "3f9efbccd2e54425aefa23beb359a84790a702fbc83e7950a709b3a56c818898" => :el_capitan
+    sha256 "db251dc1e60d49c6ba011c28cf4d08f82468af379195c66fc5e7777b6e9fc4fd" => :yosemite
+    sha256 "86fc5bddf7faf6f2897fc626903f0d927c8c9094e41c3d238c4b3e718acf4f47" => :mavericks
+  end
+
   depends_on "cmake" => :build
   depends_on "cartr/qt4/qt"
 

--- a/coin.rb
+++ b/coin.rb
@@ -5,6 +5,7 @@ class Coin < Formula
   sha256 "583478c581317862aa03a19f14c527c3888478a06284b9a46a0155fa5886d417"
 
   bottle do
+    root_url "https://homebrew.bintray.com/bottles"
     sha256 "f0f93e3c4a2b485866c9ec3a18931da88e86119854073c4e1c54ce93847f7f08" => :el_capitan
     sha256 "1b3e64aab7fe177f944b2ffcaccc3a068c992ebdd5f3047c15be513812797394" => :yosemite
     sha256 "db9f40c702a1b6955f23582988dcefd5866fa4d06589e4e16ec50ec11e64e87d" => :mavericks

--- a/cuty_capt.rb
+++ b/cuty_capt.rb
@@ -5,6 +5,14 @@ class CutyCapt < Formula
   version "0.0.6"
   sha256 "cf85226a25731aff644f87a4e40b8878154667a6725a4dc0d648d7ec2d842264"
 
+  bottle do
+    root_url "https://homebrew.bintray.com/bottles"
+    revision 1
+    sha256 "dc757b1c8e76ec43111f7eb8b232ed876b366a81f27ce53af1a828496eb8a8bb" => :el_capitan
+    sha256 "f7fe4aa211334eef9b42ee7667d416607e57ba3c7c36a24a6ad01dbb49cb97e9" => :yosemite
+    sha256 "1a4110195ff9d3837ed86b0ec73cc515c420cf07aa08ed00f5d8b1d9cae49dc3" => :mavericks
+  end
+
   depends_on "cartr/qt4/qt"
 
   def install

--- a/ezlupdate.rb
+++ b/ezlupdate.rb
@@ -6,6 +6,15 @@ class Ezlupdate < Formula
 
   head "https://github.com/ezsystems/ezpublish-legacy.git"
 
+  bottle do
+    cellar :any
+    root_url "https://homebrew.bintray.com/bottles"
+    sha256 "52ee8008a9bc66fe5183a2b6c62960e35e1433f77cf849530cd893b20ed712fb" => :el_capitan
+    sha256 "68df4f04b7e23877182f848c3626eeb6a7b6ea677042736252e337e91216fa53" => :yosemite
+    sha256 "c9ba7248ae420ad5b53cabe1a9184bac07894ec86199d024f60eaff7a3f185a6" => :mavericks
+    sha256 "4c09e545f0e9f011ed6d281a2eb3b53a5dfba04ddd4a5c6df2bc3628a285b8b5" => :mountain_lion
+  end
+
   depends_on "cartr/qt4/qt"
 
   def install

--- a/libechonest.rb
+++ b/libechonest.rb
@@ -6,6 +6,7 @@ class Libechonest < Formula
 
   bottle do
     cellar :any
+    root_url "https://homebrew.bintray.com/bottles"
     sha256 "51cae76dec59157c29e47d836d94044c75a4e69c05ded3d9fe5d16ed39029eae" => :el_capitan
     sha256 "155a7921bd0e807a5702d9cf2f85b0fa2636713c57ee2c355cf27b70bd567c79" => :yosemite
     sha256 "0e774fa6901a1d8c7244e8fcbbaefdd2a1b4f1d69d9ab3061c9dd67d468ac57b" => :mavericks

--- a/puddletag.rb
+++ b/puddletag.rb
@@ -7,6 +7,14 @@ class Puddletag < Formula
 
   head "https://github.com/keithgg/puddletag.git"
 
+  bottle do
+    cellar :any_skip_relocation
+    root_url "https://homebrew.bintray.com/bottles"
+    sha256 "2f97b0687f8eacab3188d6e2ec595f267f862efed2701e51b39a2bf81bf508bb" => :el_capitan
+    sha256 "80ad92bbf1cdaaed786063b7fc2ef78e1b652a70efbc882e1fd2c5828e3d302d" => :yosemite
+    sha256 "52b3b94916fe4943df8962f63534093a7f9a9b7f6c5e0ed4869d23b51ccd908f" => :mavericks
+  end
+
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "cartr/qt4/pyqt"
   depends_on "chromaprint" => :recommended

--- a/pyside-tools.rb
+++ b/pyside-tools.rb
@@ -6,6 +6,13 @@ class PysideTools < Formula
 
   head "https://github.com/PySide/Tools.git"
 
+  bottle do
+    root_url "https://dl.bintray.com/cartr/bottle-qt4"
+    sha256 "8fca82bd423c0f2ed505480009e30b76065e1cc2758bed45b8a2523abb150ffe" => :sierra
+    sha256 "f1513592aa38f8595825e2a339fd0cf4ab7ffbdd4cc71814291aa861ebbd5713" => :el_capitan
+    sha256 "1f61192245b05946057f47d6a73788a998c86eefc846e1d09821a316c5bc2975" => :yosemite
+  end
+
   depends_on "cmake" => :build
   depends_on "cartr/qt4/pyside"
 

--- a/pyside.rb
+++ b/pyside.rb
@@ -8,6 +8,13 @@ class Pyside < Formula
 
   head "https://github.com/PySide/PySide.git"
 
+  bottle do
+    root_url "https://dl.bintray.com/cartr/bottle-qt4"
+    sha256 "09c72363702d64409a2a6d30a47dd4995c85819a9a49b8fcdb2f5e4fc02d3b47" => :sierra
+    sha256 "d1f7a38b75e85ebdbb73d15ecd4b2154b236c80a790f021c9f70f95bc839d926" => :el_capitan
+    sha256 "8c2463514cd2133b9237143ceb2d73e64f96ff162c5c302b28f894132ad88490" => :yosemite
+  end
+
   # don't use depends_on :python because then bottles install Homebrew's python
   option "without-python", "Build without python 2 support"
   depends_on :python => :recommended if MacOS.version <= :snow_leopard

--- a/qt.rb
+++ b/qt.rb
@@ -153,5 +153,7 @@ class Qt < Formula
   bottle do
     root_url "https://dl.bintray.com/cartr/bottle-qt4"
     sha256 "5d7fcd5f7925ed4be7724aa2d1b8e14eef6e9cf786f362138e501c845ed0034f" => :sierra
+    sha256 "933b11d7efbaa066f5ab75ec56e5319e1422dec940d5035b4242e9766d0555f1" => :el_capitan
+    sha256 "63e5b332675a16fa7b13623dfa577cb49579d56b9fe43b2f8f04b0747a4ae80a" => :yosemite
   end
 end

--- a/qwtpolar.rb
+++ b/qwtpolar.rb
@@ -4,6 +4,14 @@ class Qwtpolar < Formula
   url "https://downloads.sf.net/project/qwtpolar/qwtpolar/1.1.0/qwtpolar-1.1.0.tar.bz2"
   sha256 "e45a1019b481f52a63483c536c5ef3225f1cced04abf45d7d0ff8e06d30e2355"
 
+  bottle do
+    cellar :any
+    root_url "https://homebrew.bintray.com/bottles"
+    sha256 "e51aec713366e7406d63b0eea55f41385a24d67ff7d298f9fd479ae14dea2e3c" => :el_capitan
+    sha256 "8bd14ade82bd28887ec4bfef8098cd893806b380b2176eae6885ec5da4168a54" => :yosemite
+    sha256 "cb47115b5ca12d61ccc63a2cd681323825f6a73001a02f62a1f58c8a920ae82d" => :mavericks
+  end
+
   option "with-examples", "Install source code for example apps"
   option "without-plugin", "Skip building the Qt Designer plugin"
 

--- a/rcssserver.rb
+++ b/rcssserver.rb
@@ -18,6 +18,13 @@ class Rcssserver < Formula
     end
   end
 
+  bottle do
+    root_url "https://homebrew.bintray.com/bottles"
+    sha256 "c38e5393d6d4c9074d2c70da05e0be9f61bc2f935848a3e2061a93f2b002e9af" => :el_capitan
+    sha256 "d7db1cd2a729f558cbb3569e1c858f9de8b6ced18b8eaf110b8db53881ad8c84" => :yosemite
+    sha256 "053199b5e554e73a385ffd7de6ef8bf9e04b1c3876e6fed0b9ca1c98066364a1" => :mavericks
+  end
+
   head do
     url "svn://svn.code.sf.net/p/sserver/code/rcss/trunk/rcssserver"
 

--- a/shiboken.rb
+++ b/shiboken.rb
@@ -7,6 +7,14 @@ class Shiboken < Formula
 
   head "https://github.com/PySide/Shiboken.git"
 
+  bottle do
+    rebuild 2
+    root_url "https://dl.bintray.com/cartr/bottle-qt4"
+    sha256 "07bc90641920429de9606160383f58ffae13efbc248f7704e014a57a34f3f04f" => :sierra
+    sha256 "70c2218fd33120644707710aca6cb12a68272b85afdc694a4a3fe28eb5135f8f" => :el_capitan
+    sha256 "f0f159f81858e514afd5cfc55f9c05a40ad5155baffc788974f4e632bfd97726" => :yosemite
+  end
+
   depends_on "cmake" => :build
   depends_on "cartr/qt4/qt"
 

--- a/sqliteman.rb
+++ b/sqliteman.rb
@@ -4,6 +4,13 @@ class Sqliteman < Formula
   url "https://downloads.sourceforge.net/project/sqliteman/sqliteman/1.2.2/sqliteman-1.2.2.tar.bz2"
   sha256 "2f3281f67af464c114acd0a65f05b51672e9f5b39dd52bd2570157e8f274b10f"
 
+  bottle do
+    root_url "https://homebrew.bintray.com/bottles"
+    sha256 "58aa529353dad48607eb46064df44aadea49887eb20d0df01f46452a48e48689" => :el_capitan
+    sha256 "872ac20b5090d3f91ca3cb3c518e1d318876dc5d616c1fe1e49afafa1e601c58" => :yosemite
+    sha256 "69313b1b3a7d480ab6ce4b3b544c8f0c1ea1b7128a834a82a98be97dc0344a9a" => :mavericks
+  end
+
   depends_on "cmake" => :build
 
   depends_on "cartr/qt4/qt"

--- a/valkyrie.rb
+++ b/valkyrie.rb
@@ -6,6 +6,14 @@ class Valkyrie < Formula
 
   head "svn://svn.valgrind.org/valkyrie/trunk"
 
+  bottle do
+    rebuild 1
+    root_url "https://homebrew.bintray.com/bottles"
+    sha256 "df2b8f3092c6417bfec6f7e94814a92febc364b6fecb2fa8723946f40827a1c1" => :el_capitan
+    sha256 "7992f813d519d4e70a4f1c140e664f5ffa47fea263433a1af2a0368a22754a24" => :yosemite
+    sha256 "f06323976b965095fb5bfe1c637ed42d175cdd2b4d1dedde3252788ba61b4bfa" => :mavericks
+  end
+
   depends_on "cartr/qt4/qt"
   depends_on "valgrind"
 


### PR DESCRIPTION
  * Built QT4 bottles for Yosemite & El Capitan
  * Built Shiboken, pyside and pyside-tools bottles
    for Sierra and added legacy bottles from Homebrew
  * Added legacy homebrew bottles for all other formuale

NOTE:  If a Sierra bottle is desired/created for a legacy formula,
       the Homebrew bottles will need to be copied from
       https://hombrew.bintray.com/bottles to https://bintray.com/cartr/qt4-bottles
       and the root_url will need to be changed to "https://bintray.com/cartr/qt4-bottles.

Fixes #8