### PR TITLE
Version Pyside and Coin formulae to avoid namespace clashes

### DIFF
--- a/coin@3.1.3.rb
+++ b/coin@3.1.3.rb
@@ -1,14 +1,14 @@
-class Coin < Formula
+class CoinAT313 < Formula
   desc "Retained-mode toolkit for 3D graphics development"
   homepage "https://bitbucket.org/Coin3D/coin/wiki/Home"
   url "https://bitbucket.org/Coin3D/coin/downloads/Coin-3.1.3.tar.gz"
   sha256 "583478c581317862aa03a19f14c527c3888478a06284b9a46a0155fa5886d417"
 
   bottle do
-    root_url "https://homebrew.bintray.com/bottles"
-    sha256 "f0f93e3c4a2b485866c9ec3a18931da88e86119854073c4e1c54ce93847f7f08" => :el_capitan
-    sha256 "1b3e64aab7fe177f944b2ffcaccc3a068c992ebdd5f3047c15be513812797394" => :yosemite
-    sha256 "db9f40c702a1b6955f23582988dcefd5866fa4d06589e4e16ec50ec11e64e87d" => :mavericks
+    root_url "https://dl.bintray.com/cartr/bottle-qt4"
+    sha256 "323796851c0d3556b23eaaa1ba6400a49f3235d4c0bb52c356843d03b5352f18" => :sierra
+    sha256 "91cd3072b9034640aec2ba8058f9dbfb7160802c5a1ed1d4b91b01fa7dae7dda" => :el_capitan
+    sha256 "67f8f0d490afee4095a23fb36b3334947d25d41c8693d4bd8a612a0ccf6212cc" => :yosemite
   end
 
   option "without-soqt", "Build without SoQt"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,0 +1,6 @@
+{
+  "shiboken"     : "shiboken@1.2",
+  "pyside"       : "pyside@1.2",
+  "pyside-tools" : "pyside-tools@1.2",
+  "coin"         : "coin@3.1.3"
+}

--- a/pyside-tools@1.2.rb
+++ b/pyside-tools@1.2.rb
@@ -1,4 +1,4 @@
-class PysideTools < Formula
+class PysideToolsAT12 < Formula
   desc "PySide development tools (pyuic and pyrcc)"
   homepage "https://wiki.qt.io/PySide"
   url "https://github.com/PySide/Tools/archive/0.2.15.tar.gz"
@@ -8,13 +8,13 @@ class PysideTools < Formula
 
   bottle do
     root_url "https://dl.bintray.com/cartr/bottle-qt4"
-    sha256 "8fca82bd423c0f2ed505480009e30b76065e1cc2758bed45b8a2523abb150ffe" => :sierra
-    sha256 "f1513592aa38f8595825e2a339fd0cf4ab7ffbdd4cc71814291aa861ebbd5713" => :el_capitan
-    sha256 "1f61192245b05946057f47d6a73788a998c86eefc846e1d09821a316c5bc2975" => :yosemite
+    sha256 "a33526f4dfa462958cd9f193d7cb2b07890cb03f46a93c441010e54a9cbee061" => :sierra
+    sha256 "2817916ec605546f4b0da37e4642f1383f2194e688c19d562a6888b9cef42de5" => :el_capitan
+    sha256 "a9aeb98436fb100b7a2558aee7e08221a37a83cbe803e80149171c5d655a5208" => :yosemite
   end
 
   depends_on "cmake" => :build
-  depends_on "cartr/qt4/pyside"
+  depends_on "cartr/qt4/pyside@1.2"
 
   def install
     system "cmake", ".", "-DSITE_PACKAGE=lib/python2.7/site-packages", *std_cmake_args

--- a/pyside@1.2.rb
+++ b/pyside@1.2.rb
@@ -1,18 +1,17 @@
-class Pyside < Formula
+class PysideAT12 < Formula
   desc "Python bindings for Qt"
   homepage "https://wiki.qt.io/PySide"
   url "https://download.qt.io/official_releases/pyside/pyside-qt4.8+1.2.2.tar.bz2"
   mirror "https://distfiles.macports.org/py-pyside/pyside-qt4.8+1.2.2.tar.bz2"
   sha256 "a1a9df746378efe52211f1a229f77571d1306fb72830bbf73f0d512ed9856ae1"
-  revision 1
 
   head "https://github.com/PySide/PySide.git"
 
   bottle do
     root_url "https://dl.bintray.com/cartr/bottle-qt4"
-    sha256 "09c72363702d64409a2a6d30a47dd4995c85819a9a49b8fcdb2f5e4fc02d3b47" => :sierra
-    sha256 "d1f7a38b75e85ebdbb73d15ecd4b2154b236c80a790f021c9f70f95bc839d926" => :el_capitan
-    sha256 "8c2463514cd2133b9237143ceb2d73e64f96ff162c5c302b28f894132ad88490" => :yosemite
+    sha256 "b239f0b448538cbd20929e3f123a24bd2110fb5ea32d04d76f43c8e04f34d8d5" => :sierra
+    sha256 "2dfd6a1c92af5baaab38348688fd4f439f85aea6122760caf435c58680ec3262" => :el_capitan
+    sha256 "8513a36f424c936bbc3a8fcd61e593072c6a49ca0af8e50eba8fa4985cb9fdf9" => :yosemite
   end
 
   # don't use depends_on :python because then bottles install Homebrew's python
@@ -27,9 +26,9 @@ class Pyside < Formula
   depends_on "cartr/qt4/qt"
 
   if build.with? "python3"
-    depends_on "cartr/qt4/shiboken" => "with-python3"
+    depends_on "cartr/qt4/shiboken@1.2" => "with-python3"
   else
-    depends_on "cartr/qt4/shiboken"
+    depends_on "cartr/qt4/shiboken@1.2"
   end
 
   def install

--- a/shiboken@1.2.rb
+++ b/shiboken@1.2.rb
@@ -1,5 +1,5 @@
-class Shiboken < Formula
-  desc "GeneratorRunner plugin that outputs C++ code for CPython extensions"
+class ShibokenAT12 < Formula
+  desc "C++ GeneratorRunner plugin for CPython extensions"
   homepage "https://wiki.qt.io/PySide"
   url "https://download.qt.io/official_releases/pyside/shiboken-1.2.2.tar.bz2"
   mirror "https://distfiles.macports.org/py-shiboken/shiboken-1.2.2.tar.bz2"
@@ -8,11 +8,10 @@ class Shiboken < Formula
   head "https://github.com/PySide/Shiboken.git"
 
   bottle do
-    rebuild 2
     root_url "https://dl.bintray.com/cartr/bottle-qt4"
-    sha256 "07bc90641920429de9606160383f58ffae13efbc248f7704e014a57a34f3f04f" => :sierra
-    sha256 "70c2218fd33120644707710aca6cb12a68272b85afdc694a4a3fe28eb5135f8f" => :el_capitan
-    sha256 "f0f159f81858e514afd5cfc55f9c05a40ad5155baffc788974f4e632bfd97726" => :yosemite
+    sha256 "71584344b25782198a432f4cd902ce8400cd9126e2e39c54387e713adc782069" => :sierra
+    sha256 "415b42720142450db2b52e80d707b375ce0d7da168285222cc0b2c27e0415c52" => :el_capitan
+    sha256 "d119f2d243fe7ffadde9821b3baa1385c3a5009b4dec36f0cee6cedb6d5c6442" => :yosemite
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
  * shiboken => shiboken@1.2
  * pyside => pyside@1.2
  * pyside-tools => pyside-tools@1.2
  * coin => coin@3.1.3
  * Bottled for Yosemite, El Capitan and Sierra

Closes #4