### PR TITLE
Split Qt 4 into two formulae and rename it

### DIFF
--- a/automoc4.rb
+++ b/automoc4.rb
@@ -3,6 +3,7 @@ class Automoc4 < Formula
   homepage "https://techbase.kde.org/Development/Tools/Automoc4"
   url "http://download.kde.org/stable/automoc4/0.9.88/automoc4-0.9.88.tar.bz2"
   sha256 "234116f4c05ae21d828594d652b4c4a052ef75727e2d8a4f3a4fb605de9e4c49"
+  revision 1
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles"

--- a/automoc4.rb
+++ b/automoc4.rb
@@ -12,7 +12,7 @@ class Automoc4 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
 
   # Patch needed to find Qt in Homebrew upstreamed but upstream version
   # does not apply. Won't be needed for next version.

--- a/coin@3.1.3.rb
+++ b/coin@3.1.3.rb
@@ -15,7 +15,7 @@ class CoinAT313 < Formula
 
   if build.with? "soqt"
     depends_on "pkg-config" => :build
-    depends_on "cartr/qt4/qt"
+    depends_on "cartr/qt4/qt@4"
   end
 
   resource "soqt" do

--- a/coin@3.1.3.rb
+++ b/coin@3.1.3.rb
@@ -3,6 +3,7 @@ class CoinAT313 < Formula
   homepage "https://bitbucket.org/Coin3D/coin/wiki/Home"
   url "https://bitbucket.org/Coin3D/coin/downloads/Coin-3.1.3.tar.gz"
   sha256 "583478c581317862aa03a19f14c527c3888478a06284b9a46a0155fa5886d417"
+  revision 1
 
   bottle do
     root_url "https://dl.bintray.com/cartr/bottle-qt4"

--- a/cuty_capt.rb
+++ b/cuty_capt.rb
@@ -4,6 +4,7 @@ class CutyCapt < Formula
   url "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/c/cutycapt/cutycapt_0.0~svn6.orig.tar.gz"
   version "0.0.6"
   sha256 "cf85226a25731aff644f87a4e40b8878154667a6725a4dc0d648d7ec2d842264"
+  revision 1
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles"

--- a/cuty_capt.rb
+++ b/cuty_capt.rb
@@ -13,7 +13,7 @@ class CutyCapt < Formula
     sha256 "1a4110195ff9d3837ed86b0ec73cc515c420cf07aa08ed00f5d8b1d9cae49dc3" => :mavericks
   end
 
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
 
   def install
     system "qmake", "CONFIG-=app_bundle"

--- a/ezlupdate.rb
+++ b/ezlupdate.rb
@@ -15,7 +15,7 @@ class Ezlupdate < Formula
     sha256 "4c09e545f0e9f011ed6d281a2eb3b53a5dfba04ddd4a5c6df2bc3628a285b8b5" => :mountain_lion
   end
 
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
 
   def install
     cd "support/ezlupdate-qt4.5/ezlupdate" do

--- a/ezlupdate.rb
+++ b/ezlupdate.rb
@@ -3,6 +3,7 @@ class Ezlupdate < Formula
   homepage "http://ezpedia.org/ez/ezlupdate"
   url "https://github.com/ezsystems/ezpublish-legacy/archive/v2015.01.3.tar.gz"
   sha256 "cb365cfad2f5036908dc60bbca599383fc2b61435682dacacdb7bf27ff427ce6"
+  revision 1
 
   head "https://github.com/ezsystems/ezpublish-legacy.git"
 

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -3,5 +3,5 @@
   "pyside"       : "pyside@1.2",
   "pyside-tools" : "pyside-tools@1.2",
   "coin"         : "coin@3.1.3",
-  "qt"           : "qt-webkit@2.3"
+  "qt"           : "qt-legacy-formula"
 }

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -2,5 +2,6 @@
   "shiboken"     : "shiboken@1.2",
   "pyside"       : "pyside@1.2",
   "pyside-tools" : "pyside-tools@1.2",
-  "coin"         : "coin@3.1.3"
+  "coin"         : "coin@3.1.3",
+  "qt"           : "qt-webkit@2.3"
 }

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -3,5 +3,6 @@
   "pyside"       : "pyside@1.2",
   "pyside-tools" : "pyside-tools@1.2",
   "coin"         : "coin@3.1.3",
-  "qt"           : "qt-legacy-formula"
+  "qt"           : "qt-legacy-formula",
+  "pyqt"         : "pyqt@4"
 }

--- a/frescobaldi.rb
+++ b/frescobaldi.rb
@@ -3,6 +3,7 @@ class Frescobaldi < Formula
   homepage "http://frescobaldi.org/"
   url "https://github.com/wbsoft/frescobaldi/releases/download/v2.19.0/frescobaldi-2.19.0.tar.gz"
   sha256 "b426bd53d54fdc4dfc16fcfbff957fdccfa319d6ac63614de81f6ada5044d3e6"
+  revision 1
 
   option "with-lilypond", "Install Lilypond from Homebrew/tex"
 
@@ -13,7 +14,7 @@ class Frescobaldi < Formula
   # python-poppler-qt4 dependencies
   depends_on "pkg-config" => :build
   depends_on "poppler" => "with-qt"
-  depends_on "cartr/qt4/pyqt"
+  depends_on "cartr/qt4/pyqt@4"
 
   resource "python-poppler-qt4" do
     url "https://github.com/wbsoft/python-poppler-qt4/archive/v0.24.0.tar.gz"

--- a/libechonest.rb
+++ b/libechonest.rb
@@ -14,7 +14,7 @@ class Libechonest < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
   depends_on "qjson"
 
   conflicts_with "doxygen", :because => "cmake fails to configure build."
@@ -34,7 +34,7 @@ class Libechonest < Formula
         return 0;
       }
     EOS
-    qt = Formula["cartr/qt4/qt"]
+    qt = Formula["cartr/qt4/qt@4"]
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lechonest", "-F#{qt.opt_lib}",
       "-framework", "QtCore", "-I#{qt.opt_include}/QtCore",
       "-I#{qt.opt_include}/QtNetwork", "-o", "test"

--- a/libechonest.rb
+++ b/libechonest.rb
@@ -3,6 +3,7 @@ class Libechonest < Formula
   homepage "https://projects.kde.org/projects/playground/libs/libechonest"
   url "http://files.lfranchi.com/libechonest-2.3.1.tar.bz2"
   sha256 "56756545fd1cb3d9067479f52215b6157c1ced2bc82b895e72fdcd9bebb47889"
+  revision 1
 
   bottle do
     cellar :any

--- a/puddletag.rb
+++ b/puddletag.rb
@@ -3,7 +3,7 @@ class Puddletag < Formula
   homepage "http://puddletag.sf.net"
   url "https://github.com/keithgg/puddletag/archive/1.1.1.tar.gz"
   sha256 "550680abf9c2cf082861dfb3b61fd308f87f9ed304065582cddadcc8bdd947cc"
-  revision 2
+  revision 3
 
   head "https://github.com/keithgg/puddletag.git"
 
@@ -16,7 +16,7 @@ class Puddletag < Formula
   end
 
   depends_on :python if MacOS.version <= :snow_leopard
-  depends_on "cartr/qt4/pyqt"
+  depends_on "cartr/qt4/pyqt@4"
   depends_on "chromaprint" => :recommended
 
   resource "pyparsing" do

--- a/pyqt.rb
+++ b/pyqt.rb
@@ -11,7 +11,7 @@ class Pyqt < Formula
     odie "pyqt: --with-python3 must be specified when using --without-python"
   end
 
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
 
   if build.with? "python3"
     depends_on "sip" => "with-python3"
@@ -53,8 +53,8 @@ class Pyqt < Formula
         cp_r(Dir.glob("*"), dir)
         cd dir do
           system python, "configure.py", *args
-          inreplace "pyqtconfig.py", "#{HOMEBREW_CELLAR}/#{Formula["cartr/qt4/qt"].name}/#{Formula["cartr/qt4/qt"].pkg_version}",
-            Formula["cartr/qt4/qt"].opt_prefix
+          inreplace "pyqtconfig.py", "#{HOMEBREW_CELLAR}/#{Formula["cartr/qt4/qt@4"].name}/#{Formula["cartr/qt4/qt@4"].pkg_version}",
+            Formula["cartr/qt4/qt@4"].opt_prefix
           (lib/"python#{version}/site-packages/PyQt4").install "pyqtconfig.py"
         end
       ensure

--- a/pyqt@4.rb
+++ b/pyqt@4.rb
@@ -3,6 +3,7 @@ class PyqtAT4 < Formula
   homepage "https://www.riverbankcomputing.com/software/pyqt/intro"
   url "https://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.12/PyQt4_gpl_mac-4.12.tar.gz/download"
   sha256 "19d28b09bfcb384af8c596f3f76beabd0fe4c3a2a55cd35e62402b7c7cd6f660"
+  revision 1
 
   option "without-python", "Build without python 2 support"
   depends_on :python3 => :optional

--- a/pyqt@4.rb
+++ b/pyqt@4.rb
@@ -1,4 +1,4 @@
-class Pyqt < Formula
+class PyqtAT4 < Formula
   desc "Python bindings for Qt"
   homepage "https://www.riverbankcomputing.com/software/pyqt/intro"
   url "https://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.12/PyQt4_gpl_mac-4.12.tar.gz/download"
@@ -12,6 +12,7 @@ class Pyqt < Formula
   end
 
   depends_on "cartr/qt4/qt@4"
+  depends_on "cartr/qt4/qt-webkit@2.3" => :recommended
 
   if build.with? "python3"
     depends_on "sip" => "with-python3"

--- a/pyside-tools@1.2.rb
+++ b/pyside-tools@1.2.rb
@@ -3,6 +3,7 @@ class PysideToolsAT12 < Formula
   homepage "https://wiki.qt.io/PySide"
   url "https://github.com/PySide/Tools/archive/0.2.15.tar.gz"
   sha256 "8a7fe786b19c5b2b4380aff0a9590b3129fad4a0f6f3df1f39593d79b01a9f74"
+  revision 1
 
   head "https://github.com/PySide/Tools.git"
 

--- a/pyside@1.2.rb
+++ b/pyside@1.2.rb
@@ -4,6 +4,7 @@ class PysideAT12 < Formula
   url "https://download.qt.io/official_releases/pyside/pyside-qt4.8+1.2.2.tar.bz2"
   mirror "https://distfiles.macports.org/py-pyside/pyside-qt4.8+1.2.2.tar.bz2"
   sha256 "a1a9df746378efe52211f1a229f77571d1306fb72830bbf73f0d512ed9856ae1"
+  revision 1
 
   head "https://github.com/PySide/PySide.git"
 

--- a/pyside@1.2.rb
+++ b/pyside@1.2.rb
@@ -24,6 +24,7 @@ class PysideAT12 < Formula
   depends_on "cmake" => :build
   depends_on "sphinx-doc" => :build if build.with? "docs"
   depends_on "cartr/qt4/qt@4"
+  depends_on "cartr/qt4/qt-webkit@2.3"
 
   if build.with? "python3"
     depends_on "cartr/qt4/shiboken@1.2" => "with-python3"
@@ -43,7 +44,7 @@ class PysideAT12 < Formula
         qt = Formula["cartr/qt4/qt@4"].opt_prefix
         args = std_cmake_args + %W[
           -DSITE_PACKAGE=#{lib}/python#{version}/site-packages
-          -DALTERNATIVE_QT_INCLUDE_DIR=#{qt}/include
+          -DALTERNATIVE_QT_INCLUDE_DIR=#{HOMEBREW_PREFIX}/include
           -DQT_SRC_DIR=#{qt}/src
           -DPYTHON_SUFFIX=#{python_suffix}
         ]
@@ -53,9 +54,6 @@ class PysideAT12 < Formula
         system "make", "install"
       end
     end
-
-    inreplace include/"PySide/pyside_global.h", "#{HOMEBREW_CELLAR}/#{Formula["cartr/qt4/qt@4"].name}/#{Formula["cartr/qt4/qt@4"].pkg_version}",
-       Formula["cartr/qt4/qt@4"].opt_prefix
   end
 
   test do

--- a/pyside@1.2.rb
+++ b/pyside@1.2.rb
@@ -23,7 +23,7 @@ class PysideAT12 < Formula
 
   depends_on "cmake" => :build
   depends_on "sphinx-doc" => :build if build.with? "docs"
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
 
   if build.with? "python3"
     depends_on "cartr/qt4/shiboken@1.2" => "with-python3"
@@ -40,7 +40,7 @@ class PysideAT12 < Formula
       abi = `#{python} -c 'import sysconfig as sc; print(sc.get_config_var("SOABI"))'`.strip
       python_suffix = python == "python" ? "-python2.7" : ".#{abi}"
       mkdir "macbuild#{version}" do
-        qt = Formula["cartr/qt4/qt"].opt_prefix
+        qt = Formula["cartr/qt4/qt@4"].opt_prefix
         args = std_cmake_args + %W[
           -DSITE_PACKAGE=#{lib}/python#{version}/site-packages
           -DALTERNATIVE_QT_INCLUDE_DIR=#{qt}/include
@@ -54,8 +54,8 @@ class PysideAT12 < Formula
       end
     end
 
-    inreplace include/"PySide/pyside_global.h", "#{HOMEBREW_CELLAR}/#{Formula["cartr/qt4/qt"].name}/#{Formula["cartr/qt4/qt"].pkg_version}",
-       Formula["cartr/qt4/qt"].opt_prefix
+    inreplace include/"PySide/pyside_global.h", "#{HOMEBREW_CELLAR}/#{Formula["cartr/qt4/qt@4"].name}/#{Formula["cartr/qt4/qt@4"].pkg_version}",
+       Formula["cartr/qt4/qt@4"].opt_prefix
   end
 
   test do

--- a/qbzr.rb
+++ b/qbzr.rb
@@ -3,11 +3,12 @@ class Qbzr < Formula
   homepage "https://launchpad.net/qbzr"
   url "https://launchpad.net/qbzr/0.23/0.23.1/+download/qbzr-0.23.1.tar.gz"
   sha256 "3211adef11c975dfbb6c80285651e2e6f3bfa99f1baa1a95371e8490ea8ff441"
+  revision 1
 
   bottle :unneeded
 
   depends_on "bazaar"
-  depends_on "cartr/qt4/pyqt"
+  depends_on "cartr/qt4/pyqt@4"
 
   def install
     (share/"bazaar/plugins/qbzr").install Dir["*"]

--- a/qt-legacy-formula.rb
+++ b/qt-legacy-formula.rb
@@ -1,0 +1,28 @@
+class QtLegacyFormula < Formula
+  desc "Cross-platform application and UI framework"
+  homepage "https://www.qt.io/"
+  url "https://github.com/cartr/placeholder-repo/releases/download/999.0.0/placeholder-repo-999.0.0.tar.gz"
+  sha256 "6166c138bfc80564e793fbc41c39b5e9e4c41ce4724fdba12396fbfed0887d3f"
+
+  depends_on "cartr/qt4/qt-webkit@2.3" => :recommended
+  depends_on "cartr/qt4/qt@4"
+  
+  deprecated_option "without-webkit" => "without-qt-webkit@2.3"
+
+  def install
+    opoo <<-EOS.undent
+    At the request of Homebrew maintainers, the Qt 4 formula has been
+    renamed from `qt` to `qt@4`. You may need to re-run qmake/cmake and
+    recompile any software that uses Qt 4.
+    
+    If you wrote a script/package/formula that installs Qt 4, consider 
+    find-replacing "cartr/qt4/qt" with "cartr/qt4/qt-webkit@2.3" if you
+    need Webkit support or "cartr/qt4/qt@4" if you don't.
+    
+    
+    EOS
+    
+    system "touch", "temp file uninstall qt-legacy-formula to remove"
+    bin.install "temp file uninstall qt-legacy-formula to remove"
+  end
+end

--- a/qt-webkit@2.3.rb
+++ b/qt-webkit@2.3.rb
@@ -1,0 +1,30 @@
+class QtWebkitAT23 < Formula
+  desc "Qt port of WebKit (insecure, you shouldn't use it)"
+  homepage "https://trac.webkit.org/wiki/QtWebKit"
+  url "https://download.kde.org/stable/qtwebkit-2.3/2.3.4/src/qtwebkit-2.3.4.tar.gz"
+  sha256 "c6cfa9d068f7eb024fee3f6c24f5b8b726997f669007587f35ed4a97d40097ca"
+
+  depends_on "cartr/qt4/qt@4"
+
+  def install
+    ENV["QTDIR"] = Formula["cartr/qt4/qt-base@4"].opt_prefix
+    system "Tools/Scripts/build-webkit", "--qt", "--no-webkit2", "--no-video", "--install-headers=#{include}", "--install-libs=#{lib}", "--minimal"
+    system "make", "-C", "WebKitBuild/Release", "install"
+  end
+
+  def caveats; <<-EOS.undent
+    This is years old and really insecure. You shouldn't
+    use it, especially if you don't absolutely trust the
+    HTML files you're using it to browse.
+    
+    Also, video doesn't work.
+    EOS
+  end
+  
+  bottle do
+    root_url "https://dl.bintray.com/cartr/bottle-qt4"
+    sha256 "5d7fcd5f7925ed4be7724aa2d1b8e14eef6e9cf786f362138e501c845ed0034f" => :sierra
+    sha256 "933b11d7efbaa066f5ab75ec56e5319e1422dec940d5035b4242e9766d0555f1" => :el_capitan
+    sha256 "63e5b332675a16fa7b13623dfa577cb49579d56b9fe43b2f8f04b0747a4ae80a" => :yosemite
+  end
+end

--- a/qt-webkit@2.3.rb
+++ b/qt-webkit@2.3.rb
@@ -7,7 +7,7 @@ class QtWebkitAT23 < Formula
   depends_on "cartr/qt4/qt@4"
 
   def install
-    ENV["QTDIR"] = Formula["cartr/qt4/qt-base@4"].opt_prefix
+    ENV["QTDIR"] = Formula["cartr/qt4/qt@4"].opt_prefix
     system "Tools/Scripts/build-webkit", "--qt", "--no-webkit2", "--no-video", "--install-headers=#{include}", "--install-libs=#{lib}", "--minimal"
     system "make", "-C", "WebKitBuild/Release", "install"
   end

--- a/qt-webkit@2.3.rb
+++ b/qt-webkit@2.3.rb
@@ -1,5 +1,5 @@
 class QtWebkitAT23 < Formula
-  desc "Qt port of WebKit (insecure, you shouldn't use it)"
+  desc "Qt port of WebKit (insecure, don't use for Web browsing)"
   homepage "https://trac.webkit.org/wiki/QtWebKit"
   url "https://download.kde.org/stable/qtwebkit-2.3/2.3.4/src/qtwebkit-2.3.4.tar.gz"
   sha256 "c6cfa9d068f7eb024fee3f6c24f5b8b726997f669007587f35ed4a97d40097ca"
@@ -14,8 +14,9 @@ class QtWebkitAT23 < Formula
 
   def caveats; <<-EOS.undent
     This is years old and really insecure. You shouldn't
-    use it, especially if you don't absolutely trust the
-    HTML files you're using it to browse.
+    use it if you don't absolutely trust the HTML files 
+    you're using it to browse. Definely avoid using it
+    in a general-purpose Web browser.
     
     Also, video doesn't work.
     EOS

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -93,7 +93,7 @@ class QtAT4 < Formula
     
     system "./configure", *args
     system "make"
-    ENV.j1
+    ENV.deparallelize
     system "make", "install"
     
     # Delete qmake, as we'll be rebuilding it

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -144,8 +144,8 @@ class QtAT4 < Formula
 
     Phonon is not supported on macOS Sierra or with Xcode 8.
     
-    Webkit is no longer included -- please use `brew install qt-webkit@2.3` to
-    install it.
+    WebKit is no longer included for security reasons. If you absolutely
+    need it, it can be installed with `brew install qt-webkit@2.3`.
     EOS
   end
 

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -1,10 +1,9 @@
-class Qt < Formula
+class QtAT4 < Formula
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
   url "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
   mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
   sha256 "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
-  revision 3
 
   head "https://code.qt.io/qt/qt.git", :branch => "4.8"
 
@@ -21,9 +20,7 @@ class Qt < Formula
     sha256 "0deb4cd107853b1cc0800e48bb36b3d5682dc4a2a29eb34a6d032ac4ffe32ec3"
   end
 
-  option "with-qt3support", "Build with deprecated Qt3Support module support"
   option "with-docs", "Build documentation"
-  option "without-webkit", "Build without QtWebKit module"
 
   depends_on "openssl"
   depends_on "dbus" => :optional
@@ -52,6 +49,8 @@ class Qt < Formula
       -nomake demos
       -nomake examples
       -cocoa
+      -no-webkit
+      -qt3support
     ]
 
     if ENV.compiler == :clang
@@ -84,12 +83,6 @@ class Qt < Formula
       args << "-dbus-linked"
     end
 
-    if build.with? "qt3support"
-      args << "-qt3support"
-    else
-      args << "-no-qt3support"
-    end
-
     args << "-nomake" << "docs" if build.without? "docs"
 
     if MacOS.prefer_64_bit?
@@ -97,8 +90,6 @@ class Qt < Formula
     else
       args << "-arch" << "x86"
     end
-
-    args << "-no-webkit" if build.without? "webkit"
 
     system "./configure", *args
     system "make"
@@ -108,8 +99,6 @@ class Qt < Formula
     # what are these anyway?
     (bin+"pixeltool.app").rmtree
     (bin+"qhelpconverter.app").rmtree
-    # remove porting file for non-humans
-    (prefix+"q3porting.xml").unlink if build.without? "qt3support"
 
     # Some config scripts will only find Qt in a "Frameworks" folder
     frameworks.install_symlink Dir["#{lib}/*.framework"]
@@ -120,7 +109,7 @@ class Qt < Formula
     Pathname.glob("#{lib}/*.framework/Headers") do |path|
       include.install_symlink path => path.parent.basename(".framework")
     end
-
+    
     # Make `HOMEBREW_PREFIX/lib/qt4/plugins` an additional plug-in search path
     # for Qt Designer to support formulae that provide Qt Designer plug-ins.
     system "/usr/libexec/PlistBuddy",
@@ -134,11 +123,10 @@ class Qt < Formula
     We agreed to the Qt opensource license for you.
     If this is unacceptable you should uninstall.
 
-    Qt Designer no longer picks up changes to the QT_PLUGIN_PATH environment
-    variable as it was tweaked to search for plug-ins provided by formulae in
-      #{HOMEBREW_PREFIX}/lib/qt4/plugins
-
     Phonon is not supported on macOS Sierra or with Xcode 8.
+    
+    Webkit is no longer included -- please use `brew install qt-webkit@2.3` to
+    install it.
     EOS
   end
 

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -158,9 +158,9 @@ class QtAT4 < Formula
   end
   
   bottle do
-    root_url "https://dl.bintray.com/cartr/bottle-qt4"
-    sha256 "5d7fcd5f7925ed4be7724aa2d1b8e14eef6e9cf786f362138e501c845ed0034f" => :sierra
-    sha256 "933b11d7efbaa066f5ab75ec56e5319e1422dec940d5035b4242e9766d0555f1" => :el_capitan
-    sha256 "63e5b332675a16fa7b13623dfa577cb49579d56b9fe43b2f8f04b0747a4ae80a" => :yosemite
+    root_url "https://dl.bintray.com/cartr/autobottle-qt4"
+    sha256 "3000fbb564470d6261ef934e6f62cc581bed4545f75de3bfe2eda064dd0ea078" => :sierra
+    sha256 "fef0442b1d41e0164c379ace975a76c7ecb1f9d97d7b3c511f74dff9a03c93d2" => :el_capitan
+    sha256 "8df1c3fdae7d50a3215c9f2b4affb62974ff17071abe3509d6e3260456e5d9b3" => :yosemite
   end
 end

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -90,11 +90,30 @@ class QtAT4 < Formula
     else
       args << "-arch" << "x86"
     end
-
+    
     system "./configure", *args
     system "make"
     ENV.j1
     system "make", "install"
+    
+    # Delete qmake, as we'll be rebuilding it
+    system "rm", "bin/qmake"
+    system "rm", "#{bin}/qmake"
+    system "make", "clean"
+    
+    # Patch the configure script so the built qmake can find Webkit if installed
+    inreplace "configure", '=$QT_INSTALL_PREFIX"`', "=#{HOMEBREW_PREFIX}\"`"
+    inreplace "configure", '=$QT_INSTALL_DOCS"`', "=#{HOMEBREW_PREFIX}/doc\"`"
+    inreplace "configure", '=$QT_INSTALL_HEADERS"`', "=#{HOMEBREW_PREFIX}/include\"`"
+    inreplace "configure", '=$QT_INSTALL_LIBS"`', "=#{HOMEBREW_PREFIX}/lib\"`"
+    inreplace "configure", '=$QT_INSTALL_BINS"`', "=#{HOMEBREW_PREFIX}/bin\"`"
+    inreplace "configure", '=$QT_INSTALL_PLUGINS"`', "=#{HOMEBREW_PREFIX}/lib/qt4/plugins\"`"
+    inreplace "configure", '=$QT_INSTALL_IMPORTS"`', "=#{HOMEBREW_PREFIX}/lib/qt4/imports\"`"
+    inreplace "configure", '=$QT_INSTALL_SETTINGS"`', "=#{HOMEBREW_PREFIX}\"`"
+
+    # Run ./configure again, to rebuild qmake
+    system "./configure", *args
+    bin.install "bin/qmake"
 
     # what are these anyway?
     (bin+"pixeltool.app").rmtree

--- a/qwt-qt4.rb
+++ b/qwt-qt4.rb
@@ -3,6 +3,7 @@ class QwtQt4 < Formula
   homepage "http://qwt.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.3/qwt-6.1.3.tar.bz2"
   sha256 "f3ecd34e72a9a2b08422fb6c8e909ca76f4ce5fa77acad7a2883b701f4309733"
+  revision 1
 
   option "with-qwtmathml", "Build the qwtmathml library"
   option "without-plugin", "Skip building the Qt Designer plugin"

--- a/qwt-qt4.rb
+++ b/qwt-qt4.rb
@@ -7,7 +7,7 @@ class QwtQt4 < Formula
   option "with-qwtmathml", "Build the qwtmathml library"
   option "without-plugin", "Skip building the Qt Designer plugin"
 
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
 
   # Update designer plugin linking back to qwt framework/lib after install
   # See: https://sourceforge.net/p/qwt/patches/45/
@@ -65,10 +65,10 @@ class QwtQt4 < Formula
     EOS
     system ENV.cxx, "test.cpp", "-o", "out",
       "-framework", "qwt", "-framework", "QtCore",
-      "-F#{lib}", "-F#{Formula["cartr/qt4/qt"].opt_lib}",
+      "-F#{lib}", "-F#{Formula["cartr/qt4/qt@4"].opt_lib}",
       "-I#{lib}/qwt.framework/Headers",
-      "-I#{Formula["cartr/qt4/qt"].opt_lib}/QtCore.framework/Headers",
-      "-I#{Formula["cartr/qt4/qt"].opt_lib}/QtGui.framework/Headers"
+      "-I#{Formula["cartr/qt4/qt@4"].opt_lib}/QtCore.framework/Headers",
+      "-I#{Formula["cartr/qt4/qt@4"].opt_lib}/QtGui.framework/Headers"
     system "./out"
   end
 end

--- a/qwtpolar.rb
+++ b/qwtpolar.rb
@@ -15,7 +15,7 @@ class Qwtpolar < Formula
   option "with-examples", "Install source code for example apps"
   option "without-plugin", "Skip building the Qt Designer plugin"
 
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
   depends_on "cartr/qt4/qwt-qt4"
 
   # Update designer plugin linking back to qwtpolar framework/lib after install

--- a/qwtpolar.rb
+++ b/qwtpolar.rb
@@ -3,6 +3,7 @@ class Qwtpolar < Formula
   homepage "http://qwtpolar.sourceforge.net/"
   url "https://downloads.sf.net/project/qwtpolar/qwtpolar/1.1.0/qwtpolar-1.1.0.tar.bz2"
   sha256 "e45a1019b481f52a63483c536c5ef3225f1cced04abf45d7d0ff8e06d30e2355"
+  revision 1
 
   bottle do
     cellar :any

--- a/rcssserver.rb
+++ b/rcssserver.rb
@@ -44,7 +44,7 @@ class Rcssserver < Formula
   depends_on "flex" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
 
   def install
     ENV.j1

--- a/rcssserver.rb
+++ b/rcssserver.rb
@@ -1,7 +1,7 @@
 class Rcssserver < Formula
   desc "Server for RoboCup Soccer Simulator"
   homepage "http://sserver.sourceforge.net/"
-  revision 3
+  revision 4
 
   stable do
     url "https://downloads.sourceforge.net/sserver/rcssserver/15.2.2/rcssserver-15.2.2.tar.gz"

--- a/shiboken@1.2.rb
+++ b/shiboken@1.2.rb
@@ -4,6 +4,7 @@ class ShibokenAT12 < Formula
   url "https://download.qt.io/official_releases/pyside/shiboken-1.2.2.tar.bz2"
   mirror "https://distfiles.macports.org/py-shiboken/shiboken-1.2.2.tar.bz2"
   sha256 "7625bbcf1fe313fd910c6b8c9cf49ac5495499f9d00867115a2f1f2a69fce5c4"
+  revision 1
 
   head "https://github.com/PySide/Shiboken.git"
 

--- a/shiboken@1.2.rb
+++ b/shiboken@1.2.rb
@@ -15,7 +15,7 @@ class ShibokenAT12 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
 
   # don't use depends_on :python because then bottles install Homebrew's python
   option "without-python", "Build without python 2 support"

--- a/sqliteman.rb
+++ b/sqliteman.rb
@@ -3,6 +3,7 @@ class Sqliteman < Formula
   homepage "http://www.sqliteman.com/"
   url "https://downloads.sourceforge.net/project/sqliteman/sqliteman/1.2.2/sqliteman-1.2.2.tar.bz2"
   sha256 "2f3281f67af464c114acd0a65f05b51672e9f5b39dd52bd2570157e8f274b10f"
+  revision 1
 
   bottle do
     root_url "https://homebrew.bintray.com/bottles"

--- a/sqliteman.rb
+++ b/sqliteman.rb
@@ -13,7 +13,7 @@ class Sqliteman < Formula
 
   depends_on "cmake" => :build
 
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
   depends_on "qscintilla2"
 
   def install

--- a/treeline.rb
+++ b/treeline.rb
@@ -3,12 +3,13 @@ class Treeline < Formula
   homepage "http://treeline.bellz.org/"
   url "https://downloads.sourceforge.net/project/treeline/2.0.2/treeline-2.0.2.tar.gz"
   sha256 "80379b6ebb5b825a02f4b8d0bb65d78f9895db5e25065f85353833e9d8ebd4c8"
+  revision 1
 
   bottle :unneeded
 
   depends_on :python3
   depends_on "sip" => "with-python3"
-  depends_on "cartr/qt4/pyqt" => "with-python3"
+  depends_on "cartr/qt4/pyqt@4" => "with-python3"
 
   def install
     pyver = Language::Python.major_minor_version "python3"

--- a/valkyrie.rb
+++ b/valkyrie.rb
@@ -3,6 +3,7 @@ class Valkyrie < Formula
   homepage "http://valgrind.org/downloads/guis.html"
   url "http://valgrind.org/downloads/valkyrie-2.0.0.tar.bz2"
   sha256 "a70b9ffb2409c96c263823212b4be6819154eb858825c9a19aad0ae398d59b43"
+  revision 1
 
   head "svn://svn.valgrind.org/valkyrie/trunk"
 

--- a/valkyrie.rb
+++ b/valkyrie.rb
@@ -14,7 +14,7 @@ class Valkyrie < Formula
     sha256 "f06323976b965095fb5bfe1c637ed42d175cdd2b4d1dedde3252788ba61b4bfa" => :mavericks
   end
 
-  depends_on "cartr/qt4/qt"
+  depends_on "cartr/qt4/qt@4"
   depends_on "valgrind"
 
   def install


### PR DESCRIPTION
This Pull Request:

 - Closes #5 by renaming `qt` to `qt@4`.
 - Closes #14 by disabling WebKit support in `qt@4` and creating a `qt-webkit@2.3` formula with a newer version of WebKit. The WebKit source I'm using is still pretty old, but it's significantly more recent than the one Qt 4.8 ships with. Now both `qt@4` and `qt-webkit@2.3` should build quickly enough that we can use Travis to automatically make bottles.
 - Closes #12 by unconditionally enabling Qt3Support in `qt@4`.

What's left to do before this can be merged:

- [x] Qmake projects that use WebKit fail to build unless you manually edit the Makefile to add `qt-webkit@2.3`'s cellar to the include and framework search paths. I suspect this can be solved by patching lines 4769-4782 of the configure scripts to tell the built qmake to use /usr/local instead of `qt@4`'s Cellar prefix.
- [ ] Building binary bottles using Travis
- [ ] Ensuring `pyqt` and `pyside@1.2` still build correctly and can see WebKit when it's installed.
- [x] Ensuring users who currently have `cartr/qt4/qt` installed and run `brew upgrade` correctly receive `qt@4` and `qt-webkit@2.3`.
- [x] Testing to make sure third-party Qt 4 projects still build and work correctly
  - [x] FreeCAD Homebrew formula
  - [x] Non-Homebrew program that uses `qmake`
  - [x] Non-Homebrew program that uses `cmake`
- [x] Add `revision` tag to all formulae that hard-code `qt` as the formula name somewhere. (is this all of them?)