### PR TITLE
Fix QtWebkit build when sandboxed

### DIFF
--- a/qt-webkit@2.3.rb
+++ b/qt-webkit@2.3.rb
@@ -30,10 +30,9 @@ class QtWebkitAT23 < Formula
   
   bottle do
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
-    rebuild 1
-    sha256 "6c5241ea53d8dd10484aac0c2eebcf332bfd8d19f529f35b3aa2797af9f38604" => :sierra
-    sha256 "4a974b7a50c3775c06bf53100c44b3a3df5b76d680e83114cf2f5fcc8035296b" => :el_capitan
-    sha256 "7dd4560a5167cca608d0746ef6e352f346be10c6a0ff6e08e58588e417389653" => :yosemite
+    sha256 "e01b4ee5cc9abc69bebf01f104ea9d74f3af840160d977e6d81f80d5b8bf5e4f" => :sierra
+    sha256 "fd1d1b30bb87d94e140dcdfee41ac69383b590c6166deee4056c06fa638dc8ff" => :el_capitan
+    sha256 "3b88371ffd6fb1a671e47867a9cc3561bcb4af65cc9c6dde644d9cb4aac6311d" => :yosemite
   end
 end
 

--- a/qt-webkit@2.3.rb
+++ b/qt-webkit@2.3.rb
@@ -3,11 +3,17 @@ class QtWebkitAT23 < Formula
   homepage "https://trac.webkit.org/wiki/QtWebKit"
   url "https://download.kde.org/stable/qtwebkit-2.3/2.3.4/src/qtwebkit-2.3.4.tar.gz"
   sha256 "c6cfa9d068f7eb024fee3f6c24f5b8b726997f669007587f35ed4a97d40097ca"
+  revision 1
 
   depends_on "cartr/qt4/qt@4"
 
+  # Put data and import files into this formula's cellar instead of installing them globally.
+  patch :DATA
+
   def install
     ENV["QTDIR"] = Formula["cartr/qt4/qt@4"].opt_prefix
+    ENV["INSTALL_DATA"] = "#{prefix}/etc/qt4"
+    ENV["INSTALL_LIBS"] = lib
     system "Tools/Scripts/build-webkit", "--qt", "--no-webkit2", "--no-video", "--install-headers=#{include}", "--install-libs=#{lib}", "--minimal"
     system "make", "-C", "WebKitBuild/Release", "install"
   end
@@ -30,3 +36,50 @@ class QtWebkitAT23 < Formula
     sha256 "7dd4560a5167cca608d0746ef6e352f346be10c6a0ff6e08e58588e417389653" => :yosemite
   end
 end
+
+__END__
+diff --git a/Source/WebKit/qt/declarative/experimental/experimental.pri b/Source/WebKit/qt/declarative/experimental/experimental.pri
+index 8e8d528..97075f5 100644
+--- a/Source/WebKit/qt/declarative/experimental/experimental.pri
++++ b/Source/WebKit/qt/declarative/experimental/experimental.pri
+@@ -38,10 +38,7 @@ DEFINES += HAVE_WEBKIT2
+ 
+ WEBKIT += wtf javascriptcore webkit2
+ 
+-# The fallback to QT_INSTALL_IMPORTS can be removed once we
+-# depend on Qt 5 RC1.
+-importPath = $$[QT_INSTALL_QML]
+-isEmpty(importPath): importPath = $$[QT_INSTALL_IMPORTS]
++importPath = $$(INSTALL_LIBS)/qt4/imports
+ 
+ target.path = $${importPath}/$${TARGET.module_name}
+ 
+diff --git a/Source/WebKit/qt/declarative/public.pri b/Source/WebKit/qt/declarative/public.pri
+index 7cb3bbf..77e80d0 100644
+--- a/Source/WebKit/qt/declarative/public.pri
++++ b/Source/WebKit/qt/declarative/public.pri
+@@ -46,10 +46,7 @@ SOURCES += plugin.cpp
+     QT += network
+ }
+ 
+-# The fallback to QT_INSTALL_IMPORTS can be removed once we
+-# depend on Qt 5 RC1.
+-importPath = $$[QT_INSTALL_QML]
+-isEmpty(importPath): importPath = $$[QT_INSTALL_IMPORTS]
++importPath = $$(INSTALL_LIBS)/qt4/imports
+ 
+ target.path = $${importPath}/$${TARGET.module_name}
+ 
+diff --git a/Source/api.pri b/Source/api.pri
+index f9d6fbc..413eb9b 100644
+--- a/Source/api.pri
++++ b/Source/api.pri
+@@ -118,7 +118,7 @@ haveQt(5) {
+ } else {
+     # For Qt4 we have to set up install rules manually
+     modulefile.files = $${ROOT_WEBKIT_DIR}/Tools/qmake/qt_webkit.pri
+-    mkspecs = $$[QMAKE_MKSPECS]
++    mkspecs = $$(INSTALL_DATA)/mkspecs
+     mkspecs = $$split(mkspecs, :)
+     modulefile.path = $$last(mkspecs)/modules
+     INSTALLS += modulefile

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -164,8 +164,8 @@ class QtAT4 < Formula
   
   bottle do
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
-    sha256 "e63f386e4cc6f515238aa536d3b90c08746947725f87ad0e640d0fbdc5a97177" => :sierra
-    sha256 "cfb9cc212fe351155dc9a96f269d44190bd5c16accf3f019eed18352fe86f683" => :el_capitan
-    sha256 "d1fc9d950da28cf284510bc84b902f7e223bbbf09507f1f78e76bcb8a9065919" => :yosemite
+    sha256 "3630a51e10e8a4d3d79a14e68c173a8b293e8d1431fbf2fecc56316aec592b76" => :sierra
+    sha256 "53595d29bceb3069fdbba1c81422fce677984dd44b4f34f0984842a6576b7dd6" => :el_capitan
+    sha256 "5b501c44e0e4b62226929ea20a7849feed2c764c98b7b19f8d155961e50a6cbf" => :yosemite
   end
 end

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -4,7 +4,7 @@ class QtAT4 < Formula
   url "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
   mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
   sha256 "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
-  revision 1
+  revision 2
 
   head "https://code.qt.io/qt/qt.git", :branch => "4.8"
 
@@ -20,7 +20,7 @@ class QtAT4 < Formula
     url "https://raw.githubusercontent.com/cartr/homebrew-qt4/41669527a2aac6aeb8a5eeb58f440d3f3498910a/patches/qsetting-nulls.patch"
     sha256 "0deb4cd107853b1cc0800e48bb36b3d5682dc4a2a29eb34a6d032ac4ffe32ec3"
   end
-
+  
   option "with-docs", "Build documentation"
 
   depends_on "openssl"
@@ -41,6 +41,7 @@ class QtAT4 < Formula
       -prefix #{prefix}
       -plugindir #{prefix}/lib/qt4/plugins
       -importdir #{prefix}/lib/qt4/imports
+      -datadir #{prefix}/etc/qt4
       -release
       -opensource
       -confirm-license
@@ -112,6 +113,7 @@ class QtAT4 < Formula
     inreplace "configure", '=$QT_INSTALL_BINS"`', "=#{HOMEBREW_PREFIX}/bin\"`"
     inreplace "configure", '=$QT_INSTALL_PLUGINS"`', "=#{HOMEBREW_PREFIX}/lib/qt4/plugins\"`"
     inreplace "configure", '=$QT_INSTALL_IMPORTS"`', "=#{HOMEBREW_PREFIX}/lib/qt4/imports\"`"
+    inreplace "configure", '=$QT_INSTALL_DATA"`', "=#{HOMEBREW_PREFIX}/etc/qt4\"`"
     inreplace "configure", '=$QT_INSTALL_SETTINGS"`', "=#{HOMEBREW_PREFIX}\"`"
 
     # Run ./configure again, to rebuild qmake


### PR DESCRIPTION
Homebrew recently enabled a sandbox that prevents formulae from writing outside their own Cellar directories while they're being built. The sandbox breaks `qt-webkit@2.3`, which attempts to write a mkspec to the Qt installation directory. This patch fixes this by:

1. Setting `QT_INSTALL_DATA` to a symlinked directory in the installed `qmake`, similar to what we do currently for the `lib` and `include` directories.

2. Modifying QtWebKit's build files so it writes its mkspecs and imports to a subdirectory of its Cellar. These files are then symlinked to the correct locations when you run `brew link`.

## Merge checklist

- [x] Test on my machine
- [x] Ask a third party to test it on their machine
- [x] Make sure this doesn't break PyQt
- [x] Make sure this doesn't break FreeCAD
- [x] Build bottles (will need to rebuild `qt@4`, `qt-webkit@2.3`)
- [x] Test updating
- [x] Merge!