### PR TITLE
qt@4: Fix build on macOS 10.4 and 10.5 (Tiger and Leopard)

### DIFF
--- a/patches/qt4-leopard-qfiledialog.patch
+++ b/patches/qt4-leopard-qfiledialog.patch
@@ -1,0 +1,20 @@
+diff --git a/src/gui/dialogs/qfiledialog_mac.mm b/src/gui/dialogs/qfiledialog_mac.mm
+index c51f6ad..f4bd8b8 100644
+--- a/src/gui/dialogs/qfiledialog_mac.mm
++++ b/src/gui/dialogs/qfiledialog_mac.mm
+@@ -297,6 +297,7 @@ QT_USE_NAMESPACE
+     CFURLRef url = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, (CFStringRef)filename, kCFURLPOSIXPathStyle, isDir);
+     CFBooleanRef isHidden;
+     Boolean errorOrHidden = false;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_6
+     if (!CFURLCopyResourcePropertyForKey(url, kCFURLIsHiddenKey, &isHidden, NULL)) {
+         errorOrHidden = true;
+     } else {
+@@ -304,6 +305,7 @@ QT_USE_NAMESPACE
+             errorOrHidden = true;
+         CFRelease(isHidden);
+     }
++#endif
+     CFRelease(url);
+     return errorOrHidden;
+#else

--- a/patches/qt4-tiger.patch
+++ b/patches/qt4-tiger.patch
@@ -1,0 +1,147 @@
+--- src/corelib/io/qfilesystemengine_unix.cpp.orig	2017-08-31 20:54:04.000000000 +0200
++++ src/corelib/io/qfilesystemengine_unix.cpp	2017-08-31 20:58:13.000000000 +0200
+@@ -83,6 +83,7 @@
+     return (fileInfo->finderFlags & kIsInvisible);
+ }
+ 
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
+ static bool isPackage(const QFileSystemMetaData &data, const QFileSystemEntry &entry)
+ {
+     if (!data.isDirectory())
+@@ -138,6 +139,7 @@
+     FolderInfo *folderInfo = reinterpret_cast<FolderInfo *>(catalogInfo.finderInfo);
+     return folderInfo->finderFlags & kHasBundle;
+ }
++#endif
+ 
+ #else
+ static inline bool _q_isMacHidden(const char *nativePath)
+@@ -529,8 +531,22 @@
+ 
+ #if !defined(QWS) && !defined(Q_WS_QPA) && defined(Q_OS_MAC)
+     if (what & QFileSystemMetaData::BundleType) {
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
+         if (entryExists && isPackage(data, entry))
+             data.entryFlags |= QFileSystemMetaData::BundleType;
++#else
++        if (entryExists && data.isDirectory()) {
++            QCFType<CFStringRef> path = CFStringCreateWithBytes(0,
++                    (const UInt8*)nativeFilePath, nativeFilePathLength,
++                    kCFStringEncodingUTF8, false);
++            QCFType<CFURLRef> url = CFURLCreateWithFileSystemPath(0, path,
++                    kCFURLPOSIXPathStyle, true);
++
++            UInt32 type, creator;
++            if (CFBundleGetPackageInfoInDirectory(url, &type, &creator))
++                data.entryFlags |= QFileSystemMetaData::BundleType;
++        }
++#endif
+         data.knownFlagsMask |= QFileSystemMetaData::BundleType;
+     }
+ #endif
+--- src/gui/dialogs/qfontdialog_mac.mm.orig	2017-08-31 21:41:56.000000000 +0200
++++ src/gui/dialogs/qfontdialog_mac.mm	2017-08-31 21:55:51.000000000 +0200
+@@ -141,6 +141,7 @@
+     QFont newFont;
+     if (cocoaFont) {
+         int pSize = qRound([cocoaFont pointSize]);
++#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+         CTFontDescriptorRef font = CTFontCopyFontDescriptor((CTFontRef)cocoaFont);
+         // QCoreTextFontDatabase::populateFontDatabase() is using localized names
+         QString family = QCFString::toQString((CFStringRef) CTFontDescriptorCopyLocalizedAttribute(font, kCTFontFamilyNameAttribute, NULL));
+@@ -151,6 +152,23 @@
+         newFont.setStrikeOut(resolveFont.strikeOut());
+ 
+         CFRelease(font);
++#else
++	// This pre-Leopard version is buggy and was fixed in 717e36037cf246aa201c0aaf15a5dcbd7883f159
++	// see QTBUG-27415 https://codereview.qt-project.org/#/c/42830/
++        QString family(qt_mac_NSStringToQString([cocoaFont familyName]));
++        QString typeface(qt_mac_NSStringToQString([cocoaFont fontName]));
++
++        int hyphenPos = typeface.indexOf(QLatin1Char('-'));
++        if (hyphenPos != -1) {
++            typeface.remove(0, hyphenPos + 1);
++        } else {
++            typeface = QLatin1String("Normal");
++        }
++
++        newFont = QFontDatabase().font(family, typeface, pSize);
++        newFont.setUnderline(resolveFont.underline());
++        newFont.setStrikeOut(resolveFont.strikeOut());
++#endif
+     }
+     return newFont;
+ }
+--- src/gui/painting/qpaintengine_mac.cpp.orig	2017-08-31 22:56:01.000000000 +0200
++++ src/gui/painting/qpaintengine_mac.cpp	2017-08-31 23:10:20.000000000 +0200
+@@ -334,7 +334,16 @@
+     if ((colorSpace = m_displayColorSpaceHash.value(displayID)))
+         return colorSpace;
+ 
++#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+     colorSpace = CGDisplayCopyColorSpace(displayID);
++#else
++    CMProfileRef displayProfile = 0;
++    CMError err = CMGetProfileByAVID((CMDisplayIDType)displayID, &displayProfile);
++    if (err == noErr) {
++        colorSpace = CGColorSpaceCreateWithPlatformColorSpace(displayProfile);
++        CMCloseProfile(displayProfile);
++    }
++#endif
+     if (colorSpace == 0)
+         colorSpace = CGColorSpaceCreateDeviceRGB();
+ 
+--- src/gui/painting/qprintengine_mac.mm.orig	2017-08-31 21:35:19.000000000 +0200
++++ src/gui/painting/qprintengine_mac.mm	2017-08-31 21:37:56.000000000 +0200
+@@ -187,7 +187,11 @@
+             paperMargins.top = topMargin;
+             paperMargins.right = rightMargin;
+             paperMargins.bottom = bottomMargin;
++#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+             PMPaperCreateCustom(printer, paperId, QCFString("Custom size"), customSize.width(), customSize.height(), &paperMargins, &customPaper);
++#else
++            PMPaperCreate(printer, paperId, QCFString("Custom size"), customSize.width(), customSize.height(), &paperMargins, &customPaper);
++#endif
+             PMPageFormat tmp;
+             PMCreatePageFormatWithPMPaper(&tmp, customPaper);
+             PMCopyPageFormat(tmp, format);
+--- src/gui/text/qfontdatabase_mac.cpp.orig	2017-08-31 22:45:17.000000000 +0200
++++ src/gui/text/qfontdatabase_mac.cpp	2017-08-31 23:10:46.000000000 +0200
+@@ -546,6 +546,7 @@
+ 
+ QString QFontDatabase::resolveFontFamilyAlias(const QString &family)
+ {
++#if defined(QT_MAC_USE_COCOA) && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+     QCFString expectedFamily = QCFString(family);
+ 
+     QCFType<CFMutableDictionaryRef> attributes = CFDictionaryCreateMutable(NULL, 0,
+@@ -563,6 +564,10 @@
+ 
+     QCFString familyName = (CFStringRef) CTFontDescriptorCopyLocalizedAttribute(matched, kCTFontFamilyNameAttribute, NULL);
+     return familyName;
++#else
++    // https://bugreports.qt.io/browse/QTBUG-25417?focusedCommentId=185393&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-185393
++    return family;
++#endif
+ }
+ 
+ QT_END_NAMESPACE
+--- src/network/kernel/qnetworkproxy_mac.cpp.orig	2017-08-31 21:05:13.000000000 +0200
++++ src/network/kernel/qnetworkproxy_mac.cpp	2017-08-31 21:05:44.000000000 +0200
+@@ -148,6 +148,7 @@
+ }
+ 
+ 
++#if (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
+ static QNetworkProxy proxyFromDictionary(CFDictionaryRef dict)
+ {
+     QNetworkProxy::ProxyType proxyType = QNetworkProxy::DefaultProxy;
+@@ -180,6 +181,7 @@
+ 
+     return QNetworkProxy(proxyType, hostName, port, user, password);
+ }
++#endif
+ 
+ const char * cfurlErrorDescription(SInt32 errorCode)
+ {

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -33,6 +33,12 @@ class QtAT4 < Formula
     sha256 "db68bf8397eb404c9620c6bb1ada5e98369420b1ea44f2da8c43c718814b5b3b"
   end
   
+  # Patch to fix build on macOS Leopard
+  patch do
+    url "https://raw.githubusercontent.com/cartr/homebrew-qt4/5f9f17222aaee1d6345e5979717905fe17aad7e9/patches/qt4-leopard-qfiledialog.patch"
+    sha256 "5b4cb76ae4277268bc0c8b44eef1702e69e2c0b3a658d95a85f5060662371bd2"
+  end
+  
   option "with-docs", "Build documentation"
 
   depends_on "openssl"

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -8,11 +8,25 @@ class QtAT4 < Formula
 
   head "https://code.qt.io/qt/qt.git", :branch => "4.8"
 
-  # Backport of Qt5 commit to fix the fatal build error with Xcode 7, SDK 10.11.
-  # https://code.qt.io/cgit/qt/qtbase.git/commit/?id=b06304e164ba47351fa292662c1e6383c081b5ca
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/480b7142c4e2ae07de6028f672695eb927a34875/qt/el-capitan.patch"
-    sha256 "c8a0fa819c8012a7cb70e902abb7133fc05235881ce230235d93719c47650c4e"
+  if MacOS.version >= :snow_leopard
+    # Backport of Qt5 commit to fix the fatal build error with Xcode 7, SDK 10.11.
+    # https://code.qt.io/cgit/qt/qtbase.git/commit/?id=b06304e164ba47351fa292662c1e6383c081b5ca
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/480b7142c4e2ae07de6028f672695eb927a34875/qt/el-capitan.patch"
+      sha256 "c8a0fa819c8012a7cb70e902abb7133fc05235881ce230235d93719c47650c4e"
+    end
+  else
+    # Patch to fix build on macOS Leopard
+    patch do
+      url "https://raw.githubusercontent.com/cartr/homebrew-qt4/5f9f17222aaee1d6345e5979717905fe17aad7e9/patches/qt4-leopard-qfiledialog.patch"
+      sha256 "5b4cb76ae4277268bc0c8b44eef1702e69e2c0b3a658d95a85f5060662371bd2"
+    end
+
+    # Patch to fix build on macOS Tiger
+    patch do
+      url "https://raw.githubusercontent.com/cartr/homebrew-qt4/9c34a20a60932b0bf25052252af780806d4ec4c1/patches/qt4-tiger.patch"
+      sha256 "bc96f5c2a36a9a216bf85fb0e922b19f249fb006482bd27095281da79ee50a4c"
+    end
   end
   
   # Backport of Qt5 patch to fix an issue with null bytes in QSetting strings.
@@ -31,12 +45,6 @@ class QtAT4 < Formula
   patch :p0 do
     url "https://raw.githubusercontent.com/cartr/homebrew-qt4/c957b2d755c762b77142e35f68cddd7f0986bc7b/patches/linguist-findmessage-null-check.patch"
     sha256 "db68bf8397eb404c9620c6bb1ada5e98369420b1ea44f2da8c43c718814b5b3b"
-  end
-  
-  # Patch to fix build on macOS Leopard
-  patch do
-    url "https://raw.githubusercontent.com/cartr/homebrew-qt4/5f9f17222aaee1d6345e5979717905fe17aad7e9/patches/qt4-leopard-qfiledialog.patch"
-    sha256 "5b4cb76ae4277268bc0c8b44eef1702e69e2c0b3a658d95a85f5060662371bd2"
   end
   
   option "with-docs", "Build documentation"


### PR DESCRIPTION
This PR adds a patch to fix the Qt build on Leopard. It's based on [this commit](https://github.com/mistydemeo/tigerbrew/blob/fbda1798e96437da9268dcc9e5568aa45d60e474/Library/Formula/qt.rb) from Tigerbrew.

Closes #34.