### PR TITLE
fixes deprecations, fixes #43

### DIFF
--- a/frescobaldi.rb
+++ b/frescobaldi.rb
@@ -42,7 +42,7 @@ class Frescobaldi < Formula
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     By default, a splash screen is shown on startup; this causes the main
     window not to show until the application icon on the dock is clicked
     (Cmd-Tab application switching does not appear to work).

--- a/libechonest.rb
+++ b/libechonest.rb
@@ -26,7 +26,7 @@ class Libechonest < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<-EOS.undent
+    (testpath/"test.cpp").write <<~EOS
       #include <echonest/Genre.h>
       #include <echonest/Artist.h>
       int main() {

--- a/puddletag.rb
+++ b/puddletag.rb
@@ -58,7 +58,7 @@ class Puddletag < Formula
   end
 
   test do
-    Pathname("test.py").write <<-EOS.undent
+    Pathname("test.py").write <<~EOS
       import puddlestuff
     EOS
 

--- a/pyqt@4.rb
+++ b/pyqt@4.rb
@@ -5,7 +5,7 @@ class PyqtAT4 < Formula
   sha256 "3224ab2c4d392891eb0abbc2bf076fef2ead3a5bb36ceae2383df4dda00ccce5"
 
   option "without-python", "Build without python 2 support"
-  depends_on :python3 => :optional
+  depends_on "python3" => :optional
 
   if build.without?("python3") && build.without?("python")
     odie "pyqt: --with-python3 must be specified when using --without-python"

--- a/pyqt@4.rb
+++ b/pyqt@4.rb
@@ -81,7 +81,7 @@ class PyqtAT4 < Formula
   end
 
   test do
-    Pathname("test.py").write <<-EOS.undent
+    Pathname("test.py").write <<~EOS
       from PyQt4 import QtNetwork
       QtNetwork.QNetworkAccessManager().networkAccessible()
     EOS

--- a/pyside@1.2.rb
+++ b/pyside@1.2.rb
@@ -21,7 +21,7 @@ class PysideAT12 < Formula
   # don't use depends_on :python because then bottles install Homebrew's python
   option "without-python", "Build without python 2 support"
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
-  depends_on :python3 => :optional
+  depends_on "python3" => :optional
 
   option "without-docs", "Skip building documentation"
 

--- a/qbzr.rb
+++ b/qbzr.rb
@@ -14,7 +14,7 @@ class Qbzr < Formula
     (share/"bazaar/plugins/qbzr").install Dir["*"]
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     In order to use this plugin you must set your PYTHONPATH in your ~/.bashrc:
     export PYTHONPATH="#{HOMEBREW_PREFIX}/lib/python2.7/site-packages:$PYTHONPATH"
   EOS

--- a/qt-legacy-formula.rb
+++ b/qt-legacy-formula.rb
@@ -10,7 +10,7 @@ class QtLegacyFormula < Formula
   deprecated_option "without-webkit" => "without-qt-webkit@2.3"
 
   def install
-    opoo <<-EOS.undent
+    opoo <<~EOS
     At the request of Homebrew maintainers, the Qt 4 formula has been
     renamed from `qt` to `qt@4`. You may need to re-run qmake/cmake and
     recompile any software that uses Qt 4.

--- a/qt-webkit@2.3.rb
+++ b/qt-webkit@2.3.rb
@@ -18,7 +18,7 @@ class QtWebkitAT23 < Formula
     system "make", "-C", "WebKitBuild/Release", "install"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     This is years old and really insecure. You shouldn't
     use it if you don't absolutely trust the HTML files 
     you're using it to browse. Definely avoid using it

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -159,7 +159,7 @@ class QtAT4 < Formula
     Pathname.glob("#{bin}/*.app") { |app| mv app, prefix }
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     We agreed to the Qt opensource license for you.
     If this is unacceptable you should uninstall.
 

--- a/qwt-qt4.rb
+++ b/qwt-qt4.rb
@@ -46,7 +46,7 @@ class QwtQt4 < Formula
     s = ""
 
     if build.with? "qwtmathml"
-      s += <<-EOS.undent
+      s += <<~EOS
         The qwtmathml library contains code of the MML Widget from the Qt solutions package.
         Beside the Qwt license you also have to take care of its license:
         #{opt_prefix}/qtmmlwidget-license
@@ -57,7 +57,7 @@ class QwtQt4 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<-EOS.undent
+    (testpath/"test.cpp").write <<~EOS
       #include <qwt_plot_curve.h>
       int main() {
         QwtPlotCurve *curve1 = new QwtPlotCurve("Curve 1");

--- a/shiboken@1.2.rb
+++ b/shiboken@1.2.rb
@@ -24,7 +24,7 @@ class ShibokenAT12 < Formula
   # don't use depends_on :python because then bottles install Homebrew's python
   option "without-python", "Build without python 2 support"
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
-  depends_on :python3 => :optional
+  depends_on "python3" => :optional
 
   def install
     # As of 1.1.1 the install fails unless you do an out of tree build and put

--- a/treeline.rb
+++ b/treeline.rb
@@ -7,7 +7,7 @@ class Treeline < Formula
 
   bottle :unneeded
 
-  depends_on :python3
+  depends_on "python3"
   depends_on "sip" => "with-python3"
   depends_on "cartr/qt4/pyqt@4" => "with-python3"
 


### PR DESCRIPTION
* replaced deprecated `depends_on :python3` with `depends_on "python3"` per error (#43)
* replaced deprecated `<<-EOS.undent` with `<<~EOS` per warning