### PR TITLE
Update formulae for core's Python renaming

### DIFF
--- a/frescobaldi.rb
+++ b/frescobaldi.rb
@@ -3,11 +3,11 @@ class Frescobaldi < Formula
   homepage "http://frescobaldi.org/"
   url "https://github.com/wbsoft/frescobaldi/releases/download/v2.19.0/frescobaldi-2.19.0.tar.gz"
   sha256 "b426bd53d54fdc4dfc16fcfbff957fdccfa319d6ac63614de81f6ada5044d3e6"
-  revision 1
+  revision 2
 
   option "with-lilypond", "Install Lilypond from Homebrew/tex"
 
-  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "python@2" if MacOS.version <= :snow_leopard
   depends_on "portmidi" => :optional
   depends_on "homebrew/tex/lilypond" => :optional
 

--- a/puddletag.rb
+++ b/puddletag.rb
@@ -3,7 +3,7 @@ class Puddletag < Formula
   homepage "http://puddletag.sf.net"
   url "https://github.com/keithgg/puddletag/archive/1.1.1.tar.gz"
   sha256 "550680abf9c2cf082861dfb3b61fd308f87f9ed304065582cddadcc8bdd947cc"
-  revision 3
+  revision 4
 
   head "https://github.com/keithgg/puddletag.git"
 
@@ -15,7 +15,7 @@ class Puddletag < Formula
     sha256 "52b3b94916fe4943df8962f63534093a7f9a9b7f6c5e0ed4869d23b51ccd908f" => :mavericks
   end
 
-  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on "python@2" if MacOS.version <= :snow_leopard
   depends_on "cartr/qt4/pyqt@4"
   depends_on "chromaprint" => :recommended
 

--- a/pyqt@4.rb
+++ b/pyqt@4.rb
@@ -3,19 +3,20 @@ class PyqtAT4 < Formula
   homepage "https://www.riverbankcomputing.com/software/pyqt/intro"
   url "https://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.12.1/PyQt4_gpl_mac-4.12.1.tar.gz/download"
   sha256 "3224ab2c4d392891eb0abbc2bf076fef2ead3a5bb36ceae2383df4dda00ccce5"
+  revision 1
 
-  option "without-python", "Build without python 2 support"
-  depends_on "python3" => :optional
+  option "without-python@2", "Build without python 2 support"
+  depends_on "python" => :optional
 
-  if build.without?("python3") && build.without?("python")
-    odie "pyqt: --with-python3 must be specified when using --without-python"
+  if build.without?("python") && build.without?("python@2")
+    odie "pyqt: --with-python must be specified when using --without-python@2"
   end
 
   depends_on "cartr/qt4/qt@4"
   depends_on "cartr/qt4/qt-webkit@2.3" => :recommended
 
-  if build.with? "python3"
-    depends_on "sip" => "with-python3"
+  if build.with? "python"
+    depends_on "sip" => "with-python"
   else
     depends_on "sip"
   end

--- a/pyside@1.2.rb
+++ b/pyside@1.2.rb
@@ -4,7 +4,7 @@ class PysideAT12 < Formula
   url "https://download.qt.io/official_releases/pyside/pyside-qt4.8+1.2.2.tar.bz2"
   mirror "https://distfiles.macports.org/py-pyside/pyside-qt4.8+1.2.2.tar.bz2"
   sha256 "a1a9df746378efe52211f1a229f77571d1306fb72830bbf73f0d512ed9856ae1"
-  revision 1
+  revision 2
 
   head "https://github.com/PySide/PySide.git"
 
@@ -19,9 +19,9 @@ class PysideAT12 < Formula
   end
 
   # don't use depends_on :python because then bottles install Homebrew's python
-  option "without-python", "Build without python 2 support"
-  depends_on :python => :recommended if MacOS.version <= :snow_leopard
-  depends_on "python3" => :optional
+  option "without-python@2", "Build without python 2 support"
+  depends_on "python@2" => :recommended if MacOS.version <= :snow_leopard
+  depends_on "python" => :optional
 
   option "without-docs", "Skip building documentation"
 
@@ -30,8 +30,8 @@ class PysideAT12 < Formula
   depends_on "cartr/qt4/qt@4"
   depends_on "cartr/qt4/qt-webkit@2.3"
 
-  if build.with? "python3"
-    depends_on "cartr/qt4/shiboken@1.2" => "with-python3"
+  if build.with? "python"
+    depends_on "cartr/qt4/shiboken@1.2" => "with-python"
   else
     depends_on "cartr/qt4/shiboken@1.2"
   end
@@ -43,7 +43,7 @@ class PysideAT12 < Formula
     # out of tree build in shiboken.rb.
     Language::Python.each_python(build) do |python, version|
       abi = `#{python} -c 'import sysconfig as sc; print(sc.get_config_var("SOABI"))'`.strip
-      python_suffix = python == "python" ? "-python2.7" : ".#{abi}"
+      python_suffix = python == "python2.7" ? "-python2.7" : ".#{abi}"
       mkdir "macbuild#{version}" do
         qt = Formula["cartr/qt4/qt@4"].opt_prefix
         args = std_cmake_args + %W[

--- a/shiboken@1.2.rb
+++ b/shiboken@1.2.rb
@@ -4,7 +4,7 @@ class ShibokenAT12 < Formula
   url "https://download.qt.io/official_releases/pyside/shiboken-1.2.2.tar.bz2"
   mirror "https://distfiles.macports.org/py-shiboken/shiboken-1.2.2.tar.bz2"
   sha256 "7625bbcf1fe313fd910c6b8c9cf49ac5495499f9d00867115a2f1f2a69fce5c4"
-  revision 1
+  revision 2
 
   head "https://github.com/PySide/Shiboken.git"
 
@@ -22,9 +22,9 @@ class ShibokenAT12 < Formula
   depends_on "cartr/qt4/qt@4"
 
   # don't use depends_on :python because then bottles install Homebrew's python
-  option "without-python", "Build without python 2 support"
-  depends_on :python => :recommended if MacOS.version <= :snow_leopard
-  depends_on "python3" => :optional
+  option "without-python@2", "Build without python 2 support"
+  depends_on "python@2" => :recommended if MacOS.version <= :snow_leopard
+  depends_on "python" => :optional
 
   def install
     # As of 1.1.1 the install fails unless you do an out of tree build and put
@@ -34,8 +34,8 @@ class ShibokenAT12 < Formula
         args = std_cmake_args
         # Building the tests also runs them.
         args << "-DBUILD_TESTS=ON"
-        if python == "python3" && Formula["python3"].installed?
-          python_framework = Formula["python3"].opt_prefix/"Frameworks/Python.framework/Versions/#{version}"
+        if python == "python3" && Formula["python"].installed?
+          python_framework = Formula["python"].opt_prefix/"Frameworks/Python.framework/Versions/#{version}"
           args << "-DPYTHON3_INCLUDE_DIR:PATH=#{python_framework}/Headers"
           args << "-DPYTHON3_LIBRARY:FILEPATH=#{python_framework}/lib/libpython#{version}.dylib"
         end

--- a/treeline.rb
+++ b/treeline.rb
@@ -3,13 +3,13 @@ class Treeline < Formula
   homepage "http://treeline.bellz.org/"
   url "https://downloads.sourceforge.net/project/treeline/2.0.2/treeline-2.0.2.tar.gz"
   sha256 "80379b6ebb5b825a02f4b8d0bb65d78f9895db5e25065f85353833e9d8ebd4c8"
-  revision 1
+  revision 2
 
   bottle :unneeded
 
-  depends_on "python3"
-  depends_on "sip" => "with-python3"
-  depends_on "cartr/qt4/pyqt@4" => "with-python3"
+  depends_on "python"
+  depends_on "sip" => "with-python"
+  depends_on "cartr/qt4/pyqt@4" => "with-python"
 
   def install
     pyver = Language::Python.major_minor_version "python3"


### PR DESCRIPTION
Homebrew Core recently [shuffled around their names for the Python 2 and Python 3 packages](https://github.com/Homebrew/homebrew-core/pull/24604). This PR updates our formulae to reflect this change.

- [x] Test new formulae on my machine
- [ ] Build bottles
- [x] Verify that Homebrew Core changing `python` from 2 to 3 didn't break anything
- [x] ~~Verify that this doesn't break FreeCAD~~ FreeCAD's Homebrew formula is already broken for other reasons

Closes #46.