### PR TITLE
Rebuild bottles for python-name-change formulae

### DIFF
--- a/pyqt@4.rb
+++ b/pyqt@4.rb
@@ -93,9 +93,11 @@ class PyqtAT4 < Formula
   end
   
   bottle do
+    rebuild 1
     root_url "https://dl.bintray.com/cartr/bottle-qt4"
-    sha256 "d0d79ccc4f9cd980a16911486d6cdf0fae1fd569076c9798b88cb8a4360adfe4" => :high_sierra
-    sha256 "5700cae9bbfaee265ded504e679bb6869d26a3ce11b9356e0b732ee2135489c0" => :sierra
-    sha256 "630a15e5777ecd9d66f505ff0745b91bb5cc00321729bb9f5e65630c18e275fc" => :el_capitan
+    sha256 "5c6d1faf80702fbf842192da0823615a933b4e6198824cf923c2ad52da5c598c" => :high_sierra
+    sha256 "60e060eea471ae89cad6c16c14f4c7d3ad300840de3a4694259166ce91b377f2" => :sierra
+    sha256 "73742cd1d51d3cf121e36a15fdde6ebe0d4c55abb5ca45a219a1776cec3f5b6d" => :el_capitan
+    sha256 "ea4bcda9e317579d71969c231cb3dcf3dd84b1aeb5d8cecd50ca128645e38838" => :yosemite
   end
 end

--- a/pyside@1.2.rb
+++ b/pyside@1.2.rb
@@ -10,12 +10,11 @@ class PysideAT12 < Formula
 
   bottle do
     cellar :any
-    rebuild 2
-    sha256 "83f1da35b017aae67dfb0d414ea825b990c691c107c0a5f177f26252c15c684d" => :high_sierra
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
-    sha256 "51be3a1fd82789dfee8afd5079e01685ac480cacb3c07f9cdb839f4a695488ac" => :sierra
-    sha256 "84303e789040c6fce89d499cb42308fd4a1d0f4ef7b8b5b760bf196e8c3e272a" => :el_capitan
-    sha256 "ef5894f1769a3ca2e2c8b69eb8a8fc62daa0baf107e26d43a9bc3077394c14fc" => :yosemite
+    sha256 "ef6d157776c0b19e05cd80ae3f505b0c1406cc650138157245a90c5c91e4ef39" => :high_sierra
+    sha256 "de86f87d7137c5bf6489611996e50fd89e7ba26433a5af63e74f7d77bf761774" => :sierra
+    sha256 "6c4b01a7d8d5c79cb10852800ee960ff2949ad6b905498d9f95c0ac089be9f13" => :el_capitan
+    sha256 "b1d4935c8dddea6104c3f849657540f4829b2b83f377850225aef68a3dfc484b" => :yosemite
   end
 
   # don't use depends_on :python because then bottles install Homebrew's python

--- a/shiboken@1.2.rb
+++ b/shiboken@1.2.rb
@@ -10,12 +10,11 @@ class ShibokenAT12 < Formula
 
   bottle do
     cellar :any
-    rebuild 2
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
-    sha256 "5963a64fde67d897fa61735138a5038fbb85f65048a686aba0d6c7ae1c5565f1" => :high_sierra
-    sha256 "4392a7a24506b1be9f640f1030cad073eb78877250de50ddcb237757cf9368cf" => :sierra
-    sha256 "c3d4a78614c8d094237c6c44219b682bb96cded90188e59e6aa53ab1be883c3c" => :el_capitan
-    sha256 "18fb05d0f912aa73acdccbc52a3fb4e74e86f8f905b0badd44149baaf72bb02e" => :yosemite
+    sha256 "dc505b7f9571ec2ca8f81bf335b3e45066e24069e29a68c45c8966a6698bd44e" => :high_sierra
+    sha256 "0b1ab8320d7ff126e323aec0bed3a8d388daad0986159bc69fcf04fcfb84694e" => :sierra
+    sha256 "ce7187223847c8becf32edb0bf462cfe40c90b69a68336f2f338d461c5645ac1" => :el_capitan
+    sha256 "cc2533d0f3393e429468d75663d0f4a92dcaba4912b0b9aa85212a3d89b9a36b" => :yosemite
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This PR includes rebuilt bottle hashes for the formulae changed in #47.

Closes #48.