### PR TITLE
Fix Q_OBJECT warnings on ICC

### DIFF
--- a/patches/qobject-spurious-warnings.patch
+++ b/patches/qobject-spurious-warnings.patch
@@ -6,7 +6,7 @@ index 0e0a3be..248ed91 100644
  #define Q_OBJECT_GETSTATICMETAOBJECT
  #endif
  
-+#ifdef Q_CC_CLANG
++#if defined(Q_CC_CLANG) && !defined(Q_CC_INTEL)
 +#  define Q_CC_CLANG_VERSION ((__clang_major__ * 100) + __clang_minor__)
 +#  if Q_CC_CLANG_VERSION >= 306
 +#    define QT_WARNING_PUSH                 _Pragma("clang diagnostic push")

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -4,7 +4,7 @@ class QtAT4 < Formula
   url "https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
   mirror "https://www.mirrorservice.org/sites/download.qt-project.org/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz"
   sha256 "e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0"
-  revision 4
+  revision 5
 
   head "https://code.qt.io/qt/qt.git", :branch => "4.8"
 
@@ -41,8 +41,8 @@ class QtAT4 < Formula
 
   # Patch for spurious QObject warnings
   patch :p1 do
-    url "https://raw.githubusercontent.com/cartr/homebrew-qt4/4683896e3c3123346fc0a5a7f4a9e73d7a96d6a9/patches/qobject-spurious-warnings.patch"
-    sha256 "c8f74571bf1270a9f43c8d0f2ecd110b1cec7fa63350794a77889c080621e39c"
+    url "https://raw.githubusercontent.com/cartr/homebrew-qt4/b7bc7818aa11c809209032554a990b1cef7edacc/patches/qobject-spurious-warnings.patch"
+    sha256 "5e81df9a1c35a5aec21241a82707ad6ac198b2e44928389722b64da341260c5d"
   end
 
   option "with-docs", "Build documentation"

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -192,9 +192,9 @@ class QtAT4 < Formula
   
   bottle do
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
-    sha256 "fc252b3d6f5ff42b786f467094a90d189e6055c5d51b74ae8e7a0b00478d1eaa" => :high_sierra
-    sha256 "9b050c979616df8bd622b06637b82271981d6de330eba12aca6604d1f4a9516d" => :sierra
-    sha256 "a42c56904c28f4e0ba01d0b68946764283d5934fe5722320f2176f14e896721e" => :el_capitan
-    sha256 "c5d442bbde683eea77ccf3ca185a657f8138283ee0cfcd4744d2e0dad12bc68d" => :yosemite
+    sha256 "a36630189041fd5938fba4590927756877cf6534612588cbb7952994490a38b3" => :high_sierra
+    sha256 "e0079a2e7d06ef88eadfffb4c96eaa1e08697f5792df42d973b5e52058d8b15d" => :sierra
+    sha256 "5515a907c5de5561176112baa4333161964d9bb40d2ed1f9c5e49257f5a0b7ac" => :el_capitan
+    sha256 "d62234507074af1305d2b29bb0b8eecc0c4e8f03c02b505a37cee1d5f3cfc0a2" => :yosemite
   end
 end


### PR DESCRIPTION
Closes #57.

The original version of the patch accounts for the fact that ICC pretends to be GCC. This PR revises the patch to account for ICC pretending to be Clang. (The Qt 4 source includes [similar checks](https://github.com/mumble-voip/mumble-developers-qt/blob/4.8-mumble/src/corelib/global/qglobal.h#L840).)

@swordencao, I don't have access to a copy of ICC to test this locally. Can you please check if this fixes your issue?