### PR TITLE
Fix frescobaldi build by adding a poppler-qt4 formula in the tap

### DIFF
--- a/frescobaldi.rb
+++ b/frescobaldi.rb
@@ -3,17 +3,14 @@ class Frescobaldi < Formula
   homepage "http://frescobaldi.org/"
   url "https://github.com/wbsoft/frescobaldi/releases/download/v2.19.0/frescobaldi-2.19.0.tar.gz"
   sha256 "b426bd53d54fdc4dfc16fcfbff957fdccfa319d6ac63614de81f6ada5044d3e6"
-  revision 2
-
-  option "with-lilypond", "Install Lilypond from Homebrew/tex"
+  revision 3
 
   depends_on "python@2" if MacOS.version <= :snow_leopard
   depends_on "portmidi" => :optional
-  depends_on "homebrew/tex/lilypond" => :optional
 
   # python-poppler-qt4 dependencies
   depends_on "pkg-config" => :build
-  depends_on "poppler" => "with-qt"
+  depends_on "cartr/qt4/poppler-qt4" => "with-qt@4"
   depends_on "cartr/qt4/pyqt@4"
 
   resource "python-poppler-qt4" do
@@ -28,8 +25,12 @@ class Frescobaldi < Formula
 
   def install
     ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
+
     %w[python-poppler-qt4 python-ly].each do |r|
       resource(r).stage do
+        if r == "python-poppler-qt4"
+          inreplace "types.sip", "PyList_SET_ITEM", "PyList_SetItem"
+        end
         system "python", *Language::Python.setup_install_args(libexec/"vendor")
       end
     end

--- a/poppler-qt4.rb
+++ b/poppler-qt4.rb
@@ -1,0 +1,77 @@
+class PopplerQt4 < Formula
+  desc "PDF rendering library (based on the xpdf-3.0 code base)"
+  homepage "https://poppler.freedesktop.org/"
+  url "https://poppler.freedesktop.org/poppler-0.61.1.tar.xz"
+  sha256 "1266096343f5163c1a585124e9a6d44474e1345de5cdfe55dc7b47357bcfcda9"
+
+  option "with-little-cms2", "Use color management system"
+
+  deprecated_option "with-lcms2" => "with-little-cms2"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "cairo"
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "gobject-introspection"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "openjpeg"
+  depends_on "cartr/qt4/qt@4" => :optional
+  depends_on "little-cms2" => :optional
+
+  conflicts_with "pdftohtml", "pdf2image", "xpdf",
+    :because => "poppler, pdftohtml, pdf2image, and xpdf install conflicting executables"
+
+  resource "font-data" do
+    url "https://poppler.freedesktop.org/poppler-data-0.4.8.tar.gz"
+    sha256 "1096a18161f263cccdc6d8a2eb5548c41ff8fcf9a3609243f1b6296abdf72872"
+  end
+
+  needs :cxx11 if build.with?("qt@4") || MacOS.version < :mavericks
+
+  def install
+    ENV.cxx11 if build.with?("qt@4") || MacOS.version < :mavericks
+
+    args = std_cmake_args + %w[
+      -DENABLE_XPDF_HEADERS=ON
+      -DENABLE_GLIB=ON
+      -DBUILD_GTK_TESTS=OFF
+      -DWITH_GObjectIntrospection=ON
+      -DENABLE_QT5=OFF
+    ]
+
+    if build.with? "qt@4"
+      args << "-DENABLE_QT4=ON"
+    else
+      args << "-DENABLE_QT4=OFF"
+    end
+
+    if build.with? "little-cms2"
+      args << "-DENABLE_CMS=lcms2"
+    else
+      args << "-DENABLE_CMS=OFF"
+    end
+
+    system "cmake", ".", *args
+    system "make", "install"
+    resource("font-data").stage do
+      system "make", "install", "prefix=#{prefix}"
+    end
+
+    libpoppler = (lib/"libpoppler.dylib").readlink
+    ["#{lib}/libpoppler-cpp.dylib", "#{lib}/libpoppler-glib.dylib",
+     *Dir["#{bin}/*"]].each do |f|
+      macho = MachO.open(f)
+      macho.change_dylib("@rpath/#{libpoppler}", "#{lib}/#{libpoppler}")
+      macho.write!
+    end
+  end
+
+  test do
+    system "#{bin}/pdfinfo", test_fixtures("test.pdf")
+  end
+end


### PR DESCRIPTION
Solves #22. Option --with-lilypond was removed since it is only available from homebrew-cask. 