### PR TITLE
qt@4: Fix build on Mojave

### DIFF
--- a/cuty_capt.rb
+++ b/cuty_capt.rb
@@ -6,12 +6,6 @@ class CutyCapt < Formula
   sha256 "cf85226a25731aff644f87a4e40b8878154667a6725a4dc0d648d7ec2d842264"
   revision 1
 
-  bottle do
-    root_url "https://dl.bintray.com/cartr/autobottle-qt4"
-    sha256 "hashhere" => :sierra
-    sha256 "hashhere" => :el_capitan
-  end
-
   depends_on "cartr/qt4/qt@4"
   depends_on "cartr/qt4/qt-webkit@2.3"
 

--- a/pyqt@4.rb
+++ b/pyqt@4.rb
@@ -95,6 +95,7 @@ class PyqtAT4 < Formula
   bottle do
     rebuild 1
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
+    sha256 "e44d7923a06753626ffc9bf6736b9641eb2b653bbd6ea34c841e1aaf2b9aadae" => :mojave
     sha256 "5c6d1faf80702fbf842192da0823615a933b4e6198824cf923c2ad52da5c598c" => :high_sierra
     sha256 "60e060eea471ae89cad6c16c14f4c7d3ad300840de3a4694259166ce91b377f2" => :sierra
     sha256 "73742cd1d51d3cf121e36a15fdde6ebe0d4c55abb5ca45a219a1776cec3f5b6d" => :el_capitan

--- a/pyside-tools@1.2.rb
+++ b/pyside-tools@1.2.rb
@@ -10,8 +10,9 @@ class PysideToolsAT12 < Formula
   bottle do
     cellar :any
     rebuild 2
-    sha256 "ce1705c26ff37f14d9e2c8d89de2a1cd8d1285434fc762bc5f3473152d2b5664" => :high_sierra
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
+    sha256 "6eda5d9dc88477e751efb4d0985074e1163bfe42e48805f1f4a689b01fb230cf" => :mojave
+    sha256 "ce1705c26ff37f14d9e2c8d89de2a1cd8d1285434fc762bc5f3473152d2b5664" => :high_sierra
     sha256 "08e3186ed7c36de766daf475ca60146098a0858d66bedab77cd88c18ff07b80b" => :sierra
     sha256 "96d0547e36fa48ddcc2f743909f0905b5aec03bd93bbde5409806aecc4a6c846" => :el_capitan
     sha256 "0d1c0c79a35dd143732af7998a94bb57b8ffa871fef11c05ffbd54c72ff6ec82" => :yosemite

--- a/pyside@1.2.rb
+++ b/pyside@1.2.rb
@@ -10,6 +10,7 @@ class PysideAT12 < Formula
   bottle do
     cellar :any
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
+    sha256 "c3a85d2ad28306550cc8e844ad53edd9b7756e6643f8b80b2231354c8e016f35" => :mojave
     sha256 "fae1f0246101547c9646f3bcee32c21ae006530398c812a97496c13c6ffa12ec" => :high_sierra
     sha256 "b905f9edacee0b937c7873b6e53815121776b3c9c4a6baa21522dce94fa2675f" => :sierra
     sha256 "98861a66bf700f7c38b44471b933062a285bcbdd238e17499a8beb50545115f1" => :el_capitan

--- a/qt-webkit@2.3.rb
+++ b/qt-webkit@2.3.rb
@@ -30,6 +30,7 @@ class QtWebkitAT23 < Formula
   
   bottle do
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
+    sha256 "773ffe1a0c26ab27824bed4d1d5fa55655ca0f454cc938585d122ae000fd21ff" => :mojave
     sha256 "5dd5a1c9a191e9d2c4245cad33db18044fcb501f9af3128916827eba44282ebb" => :high_sierra
     sha256 "e01b4ee5cc9abc69bebf01f104ea9d74f3af840160d977e6d81f80d5b8bf5e4f" => :sierra
     sha256 "fd1d1b30bb87d94e140dcdfee41ac69383b590c6166deee4056c06fa638dc8ff" => :el_capitan

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -205,6 +205,7 @@ class QtAT4 < Formula
   
   bottle do
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
+    sha256 "953fb1a4d035039a109079aa01e15bf1fc002060d2d7fe14540542efb5665d9e" => :mojave
     sha256 "a36630189041fd5938fba4590927756877cf6534612588cbb7952994490a38b3" => :high_sierra
     sha256 "e0079a2e7d06ef88eadfffb4c96eaa1e08697f5792df42d973b5e52058d8b15d" => :sierra
     sha256 "5515a907c5de5561176112baa4333161964d9bb40d2ed1f9c5e49257f5a0b7ac" => :el_capitan

--- a/qt@4.rb
+++ b/qt@4.rb
@@ -61,6 +61,19 @@ class QtAT4 < Formula
   end
 
   def install
+    if MacOS.sdk_path_if_needed
+      # Qt attempts to build with a 10.4 deployment target, even though
+      # we use libc++ which is only available in 10.9+. This used to not fail
+      # (although I'm unsure if the resulting binary would've worked on 10.4)
+      # but it's now completely broken because Xcode10/Mojave moved all the
+      # headers around.
+      inreplace "configure", "MACOSX_DEPLOYMENT_TARGET 10.4", "MACOSX_DEPLOYMENT_TARGET 10.9"
+      inreplace "src/tools/bootstrap/bootstrap.pro", "MACOSX_DEPLOYMENT_TARGET = 10.4", "MACOSX_DEPLOYMENT_TARGET = 10.9"
+      inreplace "mkspecs/common/mac.conf", "MACOSX_DEPLOYMENT_TARGET = 10.4", "MACOSX_DEPLOYMENT_TARGET = 10.9"
+      inreplace "qmake/qmake.pri", "MACOSX_DEPLOYMENT_TARGET = 10.4", "MACOSX_DEPLOYMENT_TARGET = 10.9"
+      inreplace "mkspecs/unsupported/macx-clang-libc++/qmake.conf", "MACOSX_DEPLOYMENT_TARGET = 10.7", "MACOSX_DEPLOYMENT_TARGET = 10.9"
+    end
+
     args = %W[
       -prefix #{prefix}
       -plugindir #{prefix}/lib/qt4/plugins

--- a/shiboken@1.2.rb
+++ b/shiboken@1.2.rb
@@ -10,6 +10,7 @@ class ShibokenAT12 < Formula
   bottle do
     cellar :any
     root_url "https://dl.bintray.com/cartr/autobottle-qt4"
+    sha256 "9ee4301c0fb346c05db64e1b83575dd5f545f5e6a5995d93c24bac1128209914" => :mojave
     sha256 "9fc153a21d3cabf6c7a996c0147b8341dafc5c631b43cb1a085ecf2dbee4ce25" => :high_sierra
     sha256 "f886aa8e05466368ab49d7396250f5ea08ee1ece1f2285470b4bb4789042e893" => :sierra
     sha256 "a81c6f85b893e75b34c624d82519c0ead1b537320922064f71fb8a841d4d8d6b" => :el_capitan


### PR DESCRIPTION
In Xcode 10/macOS Mojave, Apple moved some of the system header files around for whatever reason. The system `clang` is able to find the headers in the new locations, but it refuses to do so if your `MACOSX_DEPLOYMENT_TARGET` is lower than 10.9. It turns out that Qt was setting `MACOSX_DEPLOYMENT_TARGET=10.4`, which meant that `clang` wouldn't find the C++ standard library headers, which caused the build to fail.

This PR resolves this issue by patching Qt to set `MACOSX_DEPLOYMENT_TARGET=10.9`. This means that Qt applications compiled on a Mojave machine using this formula will no longer work on macOS versions older than Mavericks, which is probably not a huge loss.

Closes #62. @pjessesco, can you verify that this PR fixes your issue?

- [x] Test locally
- [ ] Ensure it works for @pjessesco
- [x] Build bottles