### PR TITLE
remove disabled lines which invalidate formulas on homebrew 3.4.0

### DIFF
--- a/qbzr.rb
+++ b/qbzr.rb
@@ -5,8 +5,6 @@ class Qbzr < Formula
   sha256 "3211adef11c975dfbb6c80285651e2e6f3bfa99f1baa1a95371e8490ea8ff441"
   revision 1
 
-  bottle :unneeded
-
   depends_on "bazaar"
   depends_on "cartr/qt4/pyqt@4"
 

--- a/treeline.rb
+++ b/treeline.rb
@@ -5,8 +5,6 @@ class Treeline < Formula
   sha256 "80379b6ebb5b825a02f4b8d0bb65d78f9895db5e25065f85353833e9d8ebd4c8"
   revision 2
 
-  bottle :unneeded
-
   depends_on "cartr/qt4/pyqt@4" => "with-python"
   depends_on "python"
   depends_on "sip" => "with-python"


### PR DESCRIPTION
Whatever these lines do, the fact remains that current homebrew tells you that support for them has been removed and that their presence means the entire repository cannot be used.

e.g.

```
==> Tapping cartr/qt4
Cloning into '/usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4'...
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4/treeline.rb
treeline: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the cartr/qt4 tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4/treeline.rb:8

Error: Invalid formula: /usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4/qbzr.rb
qbzr: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the cartr/qt4 tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4/qbzr.rb:8

Error: Cannot tap cartr/qt4: invalid syntax in tap!
```

Remove it and hope that it was not actually needed. Attempting to install the result seems to work.

Fixes #81